### PR TITLE
easy switch between local and remote

### DIFF
--- a/config/generator_presets.yaml
+++ b/config/generator_presets.yaml
@@ -1,0 +1,14 @@
+presets:
+  local:
+    api_key: "token-abc123"
+    method: "openai"
+    model_name: "meta-llama/Llama-2-13b-chat-hf"
+    base_url: "http://localhost:8000/v1"
+    seed: 42
+
+  remote:
+    api_key: ""
+    method: "openai"
+    model_name: "qwen-turbo-0919"
+    base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    seed: 42

--- a/sage_examples/qa_refiner.py
+++ b/sage_examples/qa_refiner.py
@@ -6,7 +6,7 @@ from sage_core.function.map_function import MapFunction
 from sage_libs.rag.retriever import DenseRetriever
 from sage_plugins.longrefiner_fn.longrefiner_adapter import LongRefinerAdapter
 from sage_libs.rag.promptor import QAPromptor
-from sage_libs.rag.generator import OpenAIGenerator
+from sage_libs.rag.generator import get_generator_preset
 
 from sage_common_funs.io.sink import TerminalSink
 from sage_common_funs.rag.evaluate import (
@@ -84,8 +84,17 @@ class TimeQAPromptor(MapFunction):
 class TimeGenerator(MapFunction):
     def __init__(self, config=None, **kwargs):
         super().__init__(**kwargs)
-        self.generator = OpenAIGenerator(config)
+        # ———— 一行切换本地 or 远程模型 ————
+        #   只需 local 或 remote，参数全在 config/generator_presets.yaml 中定义
+        self.generator = get_generator_preset("local")
+        # 如果要使用远程模型，改成：
+        # self.generator = get_generator_preset("remote")
         self.generator.runtime_context = self.runtime_context
+
+    def run(self, element):
+        # 示例流程：调用底层 generator 生成结果
+        result = self.generator.run(element)
+        return result
 
     def execute(self, data: dict):
         start = time.time()

--- a/sage_libs/rag/generator.py
+++ b/sage_libs/rag/generator.py
@@ -1,10 +1,37 @@
-import os
-from typing import Tuple,List
+import os, yaml
+from typing import Tuple, List
 from sage_common_funs.utils.generator_model import apply_generator_model
-from sage_core.function.map_function import MapFunction 
+from sage_core.function.map_function import MapFunction
 from sage_core.function.base_function import StatefulFunction
 from sage_utils.custom_logger import CustomLogger
 from sage_runtime.state_persistence import load_function_state, save_function_state
+
+_PRESETS = yaml.safe_load(open(os.path.abspath("config/generator_presets.yaml"), encoding="utf-8"))["presets"]
+
+
+def get_generator_preset(name: str) -> MapFunction:
+    """
+    返回无状态版本的 OpenAIGenerator，一行切换本地/远程：
+        gen = get_generator_preset("local")
+        gen = get_generator_preset("remote")
+    """
+    cfg = _PRESETS.get(name)
+    if cfg is None:
+        raise ValueError(f"Unknown preset: {name!r}")
+    return OpenAIGenerator(cfg)
+
+
+def get_stateful_generator_preset(name: str) -> StatefulFunction:
+    """
+    返回带对话历史的生成器版本，一行切换本地/远程：
+        gen = get_stateful_generator_preset("local")
+        gen = get_stateful_generator_preset("remote")
+    """
+    cfg = _PRESETS.get(name)
+    if cfg is None:
+        raise ValueError(f"Unknown preset: {name!r}")
+    return OpenAIGeneratorWithHistory(cfg)
+
 
 class OpenAIGenerator(MapFunction):
     """
@@ -32,8 +59,6 @@ class OpenAIGenerator(MapFunction):
         )
         self.num = 1
 
-
-
     # 其中原有的**kwargs应该由函数内部或者data内部提供
     def execute(self, data: list) -> Tuple[str, str]:
         """
@@ -47,8 +72,8 @@ class OpenAIGenerator(MapFunction):
                 and response is the generated response from the model.
         """
         # Extract the user query from the input data
-        user_query = data[0] if len(data) > 1  else None
- 
+        user_query = data[0] if len(data) > 1 else None
+
         prompt = data[1] if len(data) > 1 else data
 
         response = self.model.generate(prompt)
@@ -59,6 +84,7 @@ class OpenAIGenerator(MapFunction):
 
         # Return the generated response along with the original user query as a tuple
         return (user_query, response)
+
 
 class OpenAIGeneratorWithHistory(StatefulFunction):
     """
@@ -95,7 +121,6 @@ class OpenAIGeneratorWithHistory(StatefulFunction):
         """
         # 延迟恢复：在首次执行前根据 runtime_context 恢复状态
 
-
         user_query = data[0] if len(data) > 1 else None
         prompt_info = data[1] if len(data) > 1 else data
 
@@ -116,13 +141,13 @@ class OpenAIGeneratorWithHistory(StatefulFunction):
 
         self.logger.info(f"\033[32m[{self.__class__.__name__}] Response: {response}\033[0m")
 
-        # —— 自动持久化：每次 execute 后保存状态 —— 
+        # —— 自动持久化：每次 execute 后保存状态 ——
         base = os.path.join(self.runtime_context.session_folder, ".sage_checkpoints")
         os.makedirs(base, exist_ok=True)
         path = os.path.join(base, f"{self.runtime_context.name}.chkpt")
         save_function_state(self, path)
         return (user_query, response)
-    
+
     def save_state(self):
         """
         手动触发：持久化当前 dialogue_history，用于测试调用。
@@ -131,6 +156,7 @@ class OpenAIGeneratorWithHistory(StatefulFunction):
         os.makedirs(base, exist_ok=True)
         path = os.path.join(base, f"{self.runtime_context.name}.chkpt")
         save_function_state(self, path)
+
 
 class HFGenerator(MapFunction):
     """
@@ -164,10 +190,10 @@ class HFGenerator(MapFunction):
         :return: A Data object containing the generated response as a string.
         """
         # Generate the response from the Hugging Face model using the provided data and additional arguments
-        user_query = data[0] if len(data) > 1  else None
- 
+        user_query = data[0] if len(data) > 1 else None
+
         prompt = data[1] if len(data) > 1 else data
-        
+
         response = self.model.generate(prompt, **kwargs)
 
         # Return the generated response as a Data object


### PR DESCRIPTION
用户在 pipeline 编写 generator 类时，使用
self.generator = get_generator_preset("local") 或 self.generator = get_generator_preset("remote")
来指定本地或远程。

在 generator.py 中支持了对无状态和有状态两种方式的支持
```
def get_generator_preset(name: str) -> MapFunction:
    """
    返回无状态版本的 OpenAIGenerator，一行切换本地/远程：
        gen = get_generator_preset("local")
        gen = get_generator_preset("remote")
    """
    cfg = _PRESETS.get(name)
    if cfg is None:
        raise ValueError(f"Unknown preset: {name!r}")
    return OpenAIGenerator(cfg)


def get_stateful_generator_preset(name: str) -> StatefulFunction:
    """
    返回带对话历史的生成器版本，一行切换本地/远程：
        gen = get_stateful_generator_preset("local")
        gen = get_stateful_generator_preset("remote")
    """
    cfg = _PRESETS.get(name)
    if cfg is None:
        raise ValueError(f"Unknown preset: {name!r}")
    return OpenAIGeneratorWithHistory(cfg)
```
具体例子可以参考 qa_refiner.py 的编写方式。