### PR TITLE
feat: Add distributed Ray worker management to SAGE CLI

### DIFF
--- a/sage/cli/deploy.py
+++ b/sage/cli/deploy.py
@@ -7,107 +7,233 @@ SAGE Deploy CLI
 import typer
 import subprocess
 import sys
+import re
 from pathlib import Path
 
 app = typer.Typer(name="deploy", help="SAGE系统部署与管理")
 
+def load_config():
+    """加载配置文件（简单解析YAML格式）"""
+    config_file = Path.home() / ".sage" / "config.yaml"
+    if not config_file.exists():
+        typer.echo(f"❌ Config file not found: {config_file}")
+        typer.echo("💡 Please run setup.py first to create default config")
+        raise typer.Exit(1)
+    
+    try:
+        config = {}
+        current_section = None
+        
+        with open(config_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                
+                # 匹配section header (如 workers:)
+                section_match = re.match(r'^(\w+):\s*$', line)
+                if section_match:
+                    current_section = section_match.group(1)
+                    config[current_section] = {}
+                    continue
+                
+                # 匹配key: value对
+                kv_match = re.match(r'^(\w+):\s*(.+)$', line)
+                if kv_match and current_section:
+                    key, value = kv_match.groups()
+                    # 处理数值
+                    if value.isdigit():
+                        value = int(value)
+                    # 处理字符串，去掉引号
+                    elif value.startswith('"') and value.endswith('"'):
+                        value = value[1:-1]
+                    config[current_section][key] = value
+                    continue
+                
+                # 匹配简单赋值 (如 head_node = sage1)
+                assign_match = re.match(r'^(\w+)\s*=\s*(.+)$', line)
+                if assign_match and current_section:
+                    key, value = assign_match.groups()
+                    if value.isdigit():
+                        value = int(value)
+                    config[current_section][key] = value
+        
+        return config
+    except Exception as e:
+        typer.echo(f"❌ Failed to load config: {e}")
+        raise typer.Exit(1)
+
 @app.command("start")
 def start_system(
     ray_only: bool = typer.Option(False, "--ray-only", help="仅启动Ray集群"),
-    daemon_only: bool = typer.Option(False, "--daemon-only", help="仅启动JobManager守护进程")
+    daemon_only: bool = typer.Option(False, "--daemon-only", help="仅启动JobManager守护进程"),
+    with_workers: bool = typer.Option(False, "--with-workers", help="同时启动Worker节点")
 ):
-    """启动SAGE系统（可选仅启动Ray或Daemon）"""
-    script_path = "deployment/sage_deployment.sh"
+    """启动SAGE系统（Ray集群 + JobManager）"""
+    config = load_config()
     
-    try:
-        if ray_only:
-            print("🚀 Starting Ray cluster...")
-            subprocess.run(["bash", script_path, "start-ray"], check=True)
-        elif daemon_only:
-            print("🚀 Starting JobManager daemon...")
-            subprocess.run(["bash", script_path, "start-daemon"], check=True)
-        else:
-            print("🚀 Starting SAGE system (Ray + Daemon)...")
-            subprocess.run(["bash", script_path, "start"], check=True)
-        print("✅ System started successfully")
-    except subprocess.CalledProcessError:
-        print("❌ Failed to start system, please check environment")
-        raise typer.Exit(1)
-    except FileNotFoundError:
-        print(f"❌ Deployment script not found: {script_path}")
-        raise typer.Exit(1)
+    if not ray_only and not daemon_only:
+        typer.echo("🚀 Starting SAGE system (Ray + JobManager)...")
+    
+    # 启动Ray集群
+    if not daemon_only:
+        try:
+            typer.echo("🚀 Starting Ray cluster...")
+            workers_config = config.get('workers', {})
+            head_port = workers_config.get('head_port', 6379)
+            
+            # 启动Ray head节点，使用配置中的端口
+            ray_cmd = [
+                "ray", "start", "--head",
+                f"--port={head_port}",
+                "--dashboard-port=8265"
+            ]
+            
+            typer.echo(f"� Running: {' '.join(ray_cmd)}")
+            result = subprocess.run(ray_cmd, check=True, capture_output=True, text=True)
+            typer.echo("✅ Ray cluster started successfully")
+            
+        except subprocess.CalledProcessError as e:
+            typer.echo(f"❌ Failed to start Ray cluster: {e}")
+            typer.echo(f"❌ Error output: {e.stderr}")
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(f"❌ Unexpected error starting Ray: {e}")
+            raise typer.Exit(1)
+    
+    # 启动JobManager
+    if not ray_only:
+        try:
+            typer.echo("🚀 Starting JobManager...")
+            
+            # 使用sage jobmanager start命令
+            sage_cmd = [sys.executable, "-m", "sage.cli.jobmanager", "start"]
+            
+            typer.echo(f"💻 Running: {' '.join(sage_cmd)}")
+            result = subprocess.run(sage_cmd, check=True)
+            typer.echo("✅ JobManager started successfully")
+            
+        except subprocess.CalledProcessError as e:
+            typer.echo(f"❌ Failed to start JobManager: {e}")
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(f"❌ Unexpected error starting JobManager: {e}")
+            raise typer.Exit(1)
+    
+    if not ray_only and not daemon_only:
+        typer.echo("✅ SAGE system started successfully!")
+    elif ray_only:
+        typer.echo("✅ Ray cluster started successfully!")
+    elif daemon_only:
+        typer.echo("✅ JobManager started successfully!")
+    
+    # 启动Worker节点（如果请求）
+    if with_workers and not daemon_only:
+        try:
+            typer.echo("🚀 Starting Worker nodes...")
+            worker_cmd = [sys.executable, "-m", "sage.cli.worker_manager", "start"]
+            typer.echo(f"💻 Running: {' '.join(worker_cmd)}")
+            result = subprocess.run(worker_cmd, check=True)
+            typer.echo("✅ Worker nodes started successfully")
+        except subprocess.CalledProcessError as e:
+            typer.echo(f"⚠️  Failed to start Worker nodes: {e}")
+            # 不退出，因为head节点已经启动成功
+        except Exception as e:
+            typer.echo(f"⚠️  Unexpected error starting Worker nodes: {e}")
+            # 不退出，因为head节点已经启动成功
 
 @app.command("stop")
-def stop_system():
-    """停止SAGE系统"""
-    print("🛑 Stopping SAGE system...")
+def stop_system(
+    with_workers: bool = typer.Option(False, "--with-workers", help="同时停止Worker节点")
+):
+    """停止SAGE系统（Ray集群 + JobManager）"""
+    typer.echo("🛑 Stopping SAGE system...")
+    
+    # 停止Worker节点（如果请求）
+    if with_workers:
+        try:
+            typer.echo("🛑 Stopping Worker nodes...")
+            worker_cmd = [sys.executable, "-m", "sage.cli.worker_manager", "stop"]
+            typer.echo(f"💻 Running: {' '.join(worker_cmd)}")
+            result = subprocess.run(worker_cmd, check=True)
+            typer.echo("✅ Worker nodes stopped successfully")
+        except subprocess.CalledProcessError as e:
+            typer.echo(f"⚠️  Failed to stop Worker nodes: {e}")
+            # 继续执行，不退出
+        except Exception as e:
+            typer.echo(f"⚠️  Unexpected error stopping Worker nodes: {e}")
+            # 继续执行，不退出
+    
+    # 停止JobManager
     try:
-        subprocess.run(["bash", "deployment/sage_deployment.sh", "stop"], check=True)
-        print("✅ System stopped successfully")
-    except subprocess.CalledProcessError:
-        print("❌ Failed to stop system")
-        raise typer.Exit(1)
-    except FileNotFoundError:
-        print("❌ Deployment script not found")
-        raise typer.Exit(1)
+        typer.echo("🛑 Stopping JobManager...")
+        sage_cmd = [sys.executable, "-m", "sage.cli.jobmanager", "stop"]
+        typer.echo(f"💻 Running: {' '.join(sage_cmd)}")
+        result = subprocess.run(sage_cmd, check=True)
+        typer.echo("✅ JobManager stopped successfully")
+    except subprocess.CalledProcessError as e:
+        typer.echo(f"⚠️  Failed to stop JobManager: {e}")
+        # 继续执行，不退出
+    except Exception as e:
+        typer.echo(f"⚠️  Unexpected error stopping JobManager: {e}")
+        # 继续执行，不退出
+    
+    # 停止Ray集群
+    try:
+        typer.echo("🛑 Stopping Ray cluster...")
+        ray_cmd = ["ray", "stop"]
+        typer.echo(f"💻 Running: {' '.join(ray_cmd)}")
+        result = subprocess.run(ray_cmd, check=True, capture_output=True, text=True)
+        typer.echo("✅ Ray cluster stopped successfully")
+    except subprocess.CalledProcessError as e:
+        typer.echo(f"⚠️  Failed to stop Ray cluster: {e}")
+        typer.echo(f"⚠️  Error output: {e.stderr}")
+        # 继续执行，不退出
+    except Exception as e:
+        typer.echo(f"⚠️  Unexpected error stopping Ray: {e}")
+        # 继续执行，不退出
+    
+    typer.echo("✅ SAGE system stop completed!")
 
 @app.command("restart")
 def restart_system():
     """重启SAGE系统"""
-    print("🔄 Restarting SAGE system...")
-    try:
-        subprocess.run(["bash", "deployment/sage_deployment.sh", "restart"], check=True)
-        print("✅ System restarted successfully")
-    except subprocess.CalledProcessError:
-        print("❌ Failed to restart system")
-        raise typer.Exit(1)
-    except FileNotFoundError:
-        print("❌ Deployment script not found")
-        raise typer.Exit(1)
+    typer.echo("🔄 Restarting SAGE system...")
+    stop_system()
+    typer.echo("⏳ Waiting 3 seconds before restart...")
+    import time
+    time.sleep(3)
+    start_system()
 
 @app.command("status")
 def system_status():
     """显示系统状态"""
-    print("📊 Checking SAGE system status...")
+    typer.echo("📊 Checking SAGE system status...")
+    
+    # 检查Ray状态
     try:
-        subprocess.run(["bash", "deployment/sage_deployment.sh", "status"], check=True)
-    except subprocess.CalledProcessError:
-        print("❌ Failed to get system status")
-        raise typer.Exit(1)
+        ray_result = subprocess.run(["ray", "status"], capture_output=True, text=True)
+        if ray_result.returncode == 0:
+            typer.echo("✅ Ray cluster is running")
+            typer.echo("Ray Status:")
+            typer.echo(ray_result.stdout)
+        else:
+            typer.echo("❌ Ray cluster is not running")
     except FileNotFoundError:
-        print("❌ Deployment script not found")
-        raise typer.Exit(1)
-
-@app.command("health")
-def health_check():
-    """健康检查"""
-    print("🔍 Performing health check...")
+        typer.echo("❌ Ray command not found")
+    except Exception as e:
+        typer.echo(f"❌ Error checking Ray status: {e}")
+    
+    # 检查JobManager状态
     try:
-        subprocess.run(["bash", "deployment/sage_deployment.sh", "health"], check=True)
-        print("✅ Health check completed")
-    except subprocess.CalledProcessError:
-        print("❌ Health check failed")
-        raise typer.Exit(1)
-    except FileNotFoundError:
-        print("❌ Deployment script not found")
-        raise typer.Exit(1)
-
-@app.command("monitor")
-def monitor_system(
-    refresh: int = typer.Option(5, "--refresh", "-r", help="刷新间隔（秒）")
-):
-    """实时监控系统"""
-    print(f"📈 Real-time monitoring SAGE system, refresh every {refresh}s...")
-    try:
-        subprocess.run(["bash", "deployment/sage_deployment.sh", "monitor", str(refresh)], check=True)
-    except subprocess.CalledProcessError:
-        print("❌ Monitoring failed")
-        raise typer.Exit(1)
-    except FileNotFoundError:
-        print("❌ Deployment script not found")
-        raise typer.Exit(1)
-    except KeyboardInterrupt:
-        print("\n🛑 Monitoring stopped")
+        jm_cmd = [sys.executable, "-m", "sage.cli.jobmanager", "status"]
+        jm_result = subprocess.run(jm_cmd, capture_output=True, text=True)
+        if jm_result.returncode == 0:
+            typer.echo("✅ JobManager is running")
+        else:
+            typer.echo("❌ JobManager is not running")
+    except Exception as e:
+        typer.echo(f"❌ Error checking JobManager status: {e}")
 
 if __name__ == "__main__":
     app()

--- a/sage/cli/main.py
+++ b/sage/cli/main.py
@@ -11,6 +11,7 @@ from typing import Optional
 from sage.cli.job import app as job_app
 from sage.cli.deploy import app as deploy_app
 from sage.cli.jobmanager import app as jobmanager_app
+from sage.cli.worker_manager import app as worker_app
 
 # 创建主应用
 app = typer.Typer(
@@ -23,6 +24,7 @@ app = typer.Typer(
 app.add_typer(job_app, name="job", help="📋 作业管理 - 提交、监控、管理作业")
 app.add_typer(deploy_app, name="deploy", help="🎯 系统部署 - 启动、停止、监控系统")
 app.add_typer(jobmanager_app, name="jobmanager", help="🛠️ JobManager管理 - 启动、停止、重启JobManager")
+app.add_typer(worker_app, name="worker", help="👥 Worker管理 - 管理Ray集群的Worker节点")
 
 @app.command("version")
 def version():
@@ -36,21 +38,20 @@ def version():
 def config_info():
     """显示配置信息"""
     from pathlib import Path
-    import yaml
+    import re
     
     config_path = Path.home() / ".sage" / "config.yaml"
     
     if config_path.exists():
         try:
-            with open(config_path) as f:
-                config = yaml.safe_load(f)
             print("📋 Current SAGE Configuration:")
-            print(yaml.dump(config, default_flow_style=False))
+            with open(config_path, 'r', encoding='utf-8') as f:
+                print(f.read())
         except Exception as e:
             print(f"❌ Failed to load config: {e}")
     else:
-        print("ℹ️  No configuration file found at ~/.sage/config.yaml")
-        print("   Using default settings")
+        print("❌ Config file not found. Please run setup.py first.")
+        print("💡 Location should be: ~/.sage/config.yaml")
 
 @app.callback()
 def main(

--- a/sage/cli/setup.py
+++ b/sage/cli/setup.py
@@ -55,6 +55,19 @@ monitor:
 jobmanager:
   timeout: 30
   retry_attempts: 3
+
+# Ray cluster configuration
+workers:
+  head_node: "base-sage"
+  worker_nodes: "sage2:22,sage4:22"
+  ssh_user: "sage"
+  ssh_key_path: "~/.ssh/id_rsa"
+  head_port: 6379
+  worker_temp_dir: "/tmp/ray_worker"
+  worker_log_dir: "/tmp/sage_worker_logs"
+  remote_sage_home: "/home/sage"
+  remote_python_path: "/opt/conda/envs/sage/bin/python"
+  remote_ray_command: "/opt/conda/envs/sage/bin/ray"
 """
         config_file.write_text(default_config)
         print(f"✅ Created default config: {config_file}")

--- a/sage/cli/worker_manager.py
+++ b/sage/cli/worker_manager.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""
+SAGE Worker Manager CLI
+Ray Worker节点管理相关命令
+"""
+
+import typer
+import subprocess
+import sys
+import re
+import tempfile
+import os
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+app = typer.Typer(name="worker", help="Ray Worker节点管理")
+
+def load_config():
+    """加载配置文件（简单解析YAML格式）"""
+    config_file = Path.home() / ".sage" / "config.yaml"
+    if not config_file.exists():
+        typer.echo(f"❌ Config file not found: {config_file}")
+        typer.echo("💡 Please run setup.py first to create default config")
+        raise typer.Exit(1)
+    
+    try:
+        config = {}
+        current_section = None
+        
+        with open(config_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                
+                # 匹配section header (如 workers:)
+                section_match = re.match(r'^(\w+):\s*$', line)
+                if section_match:
+                    current_section = section_match.group(1)
+                    config[current_section] = {}
+                    continue
+                
+                # 匹配key: value对
+                kv_match = re.match(r'^(\w+):\s*(.+)$', line)
+                if kv_match and current_section:
+                    key, value = kv_match.groups()
+                    # 处理数值
+                    if value.isdigit():
+                        value = int(value)
+                    # 处理字符串，去掉引号
+                    elif value.startswith('"') and value.endswith('"'):
+                        value = value[1:-1]
+                    config[current_section][key] = value
+                    continue
+                
+                # 匹配简单赋值 (如 head_node = sage1)
+                assign_match = re.match(r'^(\w+)\s*=\s*(.+)$', line)
+                if assign_match and current_section:
+                    key, value = assign_match.groups()
+                    if value.isdigit():
+                        value = int(value)
+                    config[current_section][key] = value
+        
+        return config
+    except Exception as e:
+        typer.echo(f"❌ Failed to load config: {e}")
+        raise typer.Exit(1)
+
+def parse_worker_nodes(worker_nodes_str: str) -> List[Tuple[str, int]]:
+    """解析worker节点列表"""
+    nodes = []
+    for node in worker_nodes_str.split(','):
+        node = node.strip()
+        if ':' in node:
+            host, port = node.split(':', 1)
+            port = int(port)
+        else:
+            host = node
+            port = 22  # 默认SSH端口
+        nodes.append((host, port))
+    return nodes
+
+def execute_remote_command(host: str, port: int, command: str, ssh_user: str, ssh_key_path: str, timeout: int = 60) -> bool:
+    """在远程主机上执行命令"""
+    typer.echo(f"🔗 连接到 {ssh_user}@{host}:{port}")
+    
+    # 创建临时脚本文件
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.sh', delete=False) as temp_script:
+        temp_script.write("#!/bin/bash\n")
+        temp_script.write(command)
+        temp_script_path = temp_script.name
+    
+    try:
+        ssh_cmd = [
+            'ssh',
+            '-i', os.path.expanduser(ssh_key_path),
+            '-p', str(port),
+            '-o', 'StrictHostKeyChecking=no',
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'ConnectTimeout=10',
+            '-o', 'ServerAliveInterval=60',
+            '-o', 'ServerAliveCountMax=3',
+            f'{ssh_user}@{host}',
+            'bash -s'
+        ]
+        
+        with open(temp_script_path, 'r') as script_file:
+            result = subprocess.run(
+                ssh_cmd,
+                stdin=script_file,
+                capture_output=True,
+                text=True,
+                timeout=timeout
+            )
+        
+        if result.stdout:
+            typer.echo(result.stdout)
+        if result.stderr:
+            typer.echo(result.stderr, err=True)
+        
+        return result.returncode == 0
+        
+    except subprocess.TimeoutExpired:
+        typer.echo(f"❌ Remote command timeout ({timeout}s)")
+        return False
+    except Exception as e:
+        typer.echo(f"❌ Remote command failed: {e}")
+        return False
+    finally:
+        # 清理临时文件
+        try:
+            os.unlink(temp_script_path)
+        except OSError:
+            pass
+
+def get_conda_init_code(remote_conda_env: str = "sage") -> str:
+    """获取Conda环境初始化代码"""
+    return f'''
+# 多种conda安装路径尝试
+for conda_path in \\
+    "$HOME/miniconda3/etc/profile.d/conda.sh" \\
+    "$HOME/anaconda3/etc/profile.d/conda.sh" \\
+    "/opt/conda/etc/profile.d/conda.sh" \\
+    "/usr/local/miniconda3/etc/profile.d/conda.sh" \\
+    "/usr/local/anaconda3/etc/profile.d/conda.sh"; do
+    if [ -f "$conda_path" ]; then
+        source "$conda_path"
+        echo "[INFO] 找到conda: $conda_path"
+        CONDA_FOUND=true
+        break
+    fi
+done
+
+if [ -z "$CONDA_FOUND" ]; then
+    echo "[ERROR] 未找到conda安装，请检查conda是否正确安装"
+    exit 1
+fi
+
+# 激活sage环境
+if ! conda activate {remote_conda_env}; then
+    echo "[ERROR] 无法激活conda环境: {remote_conda_env}"
+    echo "[INFO] 可用的conda环境:"
+    conda env list
+    exit 1
+fi
+
+echo "[SUCCESS] 已激活conda环境: {remote_conda_env}"
+'''
+
+@app.command("start")
+def start_workers():
+    """启动所有Ray Worker节点"""
+    typer.echo("🚀 启动Ray Worker节点...")
+    config = load_config()
+    
+    workers_config = config.get('workers', {})
+    head_node = workers_config.get('head_node')
+    worker_nodes = workers_config.get('worker_nodes')
+    head_port = workers_config.get('head_port', 6379)
+    ssh_user = workers_config.get('ssh_user', 'sage')
+    ssh_key_path = workers_config.get('ssh_key_path', '~/.ssh/id_rsa')
+    worker_temp_dir = workers_config.get('worker_temp_dir', '/tmp/ray_worker')
+    worker_log_dir = workers_config.get('worker_log_dir', '/tmp/sage_worker_logs')
+    remote_sage_home = workers_config.get('remote_sage_home', '/home/sage')
+    remote_python_path = workers_config.get('remote_python_path', '/opt/conda/envs/sage/bin/python')
+    remote_ray_command = workers_config.get('remote_ray_command', '/opt/conda/envs/sage/bin/ray')
+    
+    if not head_node or not worker_nodes:
+        typer.echo("❌ 配置错误: head_node 或 worker_nodes 未设置")
+        raise typer.Exit(1)
+    
+    typer.echo(f"📋 配置信息:")
+    typer.echo(f"   Head节点: {head_node}:{head_port}")
+    typer.echo(f"   Worker节点: {worker_nodes}")
+    typer.echo(f"   SSH用户: {ssh_user}")
+    
+    nodes = parse_worker_nodes(worker_nodes)
+    success_count = 0
+    total_count = len(nodes)
+    
+    for i, (host, port) in enumerate(nodes, 1):
+        typer.echo(f"\n🔧 启动Worker节点 {i}/{total_count}: {host}:{port}")
+        
+        start_command = f'''set -e
+export PYTHONUNBUFFERED=1
+
+# 当前主机名
+CURRENT_HOST='{host}'
+
+# 创建必要目录
+LOG_DIR='{worker_log_dir}'
+WORKER_TEMP_DIR='{worker_temp_dir}'
+mkdir -p "$LOG_DIR" "$WORKER_TEMP_DIR"
+
+# 记录启动时间
+echo "===============================================" | tee -a "$LOG_DIR/worker.log"
+echo "Ray Worker启动 ($(date '+%Y-%m-%d %H:%M:%S'))" | tee -a "$LOG_DIR/worker.log"
+echo "Worker节点: $(hostname)" | tee -a "$LOG_DIR/worker.log"
+echo "目标头节点: {head_node}:{head_port}" | tee -a "$LOG_DIR/worker.log"
+echo "===============================================" | tee -a "$LOG_DIR/worker.log"
+
+# 初始化conda环境
+{get_conda_init_code()}
+
+# 停止现有的ray进程
+echo "[INFO] 停止现有Ray进程..." | tee -a "$LOG_DIR/worker.log"
+{remote_ray_command} stop >> "$LOG_DIR/worker.log" 2>&1 || true
+sleep 2
+
+# 强制清理残留进程
+echo "[INFO] 强制清理所有Ray相关进程..." | tee -a "$LOG_DIR/worker.log"
+for proc in raylet core_worker log_monitor; do
+    PIDS=$(pgrep -f "$proc" 2>/dev/null || true)
+    if [[ -n "$PIDS" ]]; then
+        echo "[INFO] 发现$proc进程: $PIDS" | tee -a "$LOG_DIR/worker.log"
+        echo "$PIDS" | xargs -r kill -TERM 2>/dev/null || true
+        sleep 2
+    fi
+done
+
+# 清理Ray会话目录
+echo "[INFO] 清理Ray会话目录..." | tee -a "$LOG_DIR/worker.log"
+rm -rf "$WORKER_TEMP_DIR"/* 2>/dev/null || true
+
+sleep 3
+
+# 使用配置文件中指定的节点名称
+NODE_IP="$CURRENT_HOST"
+echo "[INFO] 使用节点名称: $NODE_IP" | tee -a "$LOG_DIR/worker.log"
+
+# 设置环境变量
+export RAY_TMPDIR="$WORKER_TEMP_DIR"
+export RAY_DISABLE_IMPORT_WARNING=1
+
+# 测试连通性
+echo "[INFO] 测试到头节点的连通性..." | tee -a "$LOG_DIR/worker.log"
+if timeout 10 nc -z {head_node} {head_port} 2>/dev/null; then
+    echo "[SUCCESS] 可以连接到头节点 {head_node}:{head_port}" | tee -a "$LOG_DIR/worker.log"
+else
+    echo "[WARNING] 无法验证到头节点的连通性，但继续尝试启动Ray" | tee -a "$LOG_DIR/worker.log"
+fi
+
+# 启动ray worker
+echo "[INFO] 启动Ray Worker进程..." | tee -a "$LOG_DIR/worker.log"
+RAY_START_CMD="{remote_ray_command} start --address={head_node}:{head_port} --node-ip-address=$NODE_IP --temp-dir=$WORKER_TEMP_DIR"
+echo "[INFO] 执行命令: $RAY_START_CMD" | tee -a "$LOG_DIR/worker.log"
+
+$RAY_START_CMD >> "$LOG_DIR/worker.log" 2>&1
+RAY_EXIT_CODE=$?
+
+if [ $RAY_EXIT_CODE -eq 0 ]; then
+    echo "[SUCCESS] Ray Worker启动成功" | tee -a "$LOG_DIR/worker.log"
+    sleep 3
+    
+    RAY_PIDS=$(pgrep -f 'raylet|core_worker' || true)
+    if [[ -n "$RAY_PIDS" ]]; then
+        echo "[SUCCESS] Ray Worker进程正在运行，PIDs: $RAY_PIDS" | tee -a "$LOG_DIR/worker.log"
+        echo "[INFO] 节点已连接到集群: {head_node}:{head_port}" | tee -a "$LOG_DIR/worker.log"
+    else
+        echo "[WARNING] Ray启动命令成功但未发现运行中的进程" | tee -a "$LOG_DIR/worker.log"
+    fi
+else
+    echo "[ERROR] Ray Worker启动失败，退出码: $RAY_EXIT_CODE" | tee -a "$LOG_DIR/worker.log"
+    exit 1
+fi'''
+        
+        if execute_remote_command(host, port, start_command, ssh_user, ssh_key_path, 120):
+            typer.echo(f"✅ Worker节点 {host} 启动成功")
+            success_count += 1
+        else:
+            typer.echo(f"❌ Worker节点 {host} 启动失败")
+    
+    typer.echo(f"\n📊 启动结果: {success_count}/{total_count} 个节点启动成功")
+    if success_count == total_count:
+        typer.echo("✅ 所有Worker节点启动成功！")
+    else:
+        typer.echo("⚠️  部分Worker节点启动失败")
+        raise typer.Exit(1)
+
+@app.command("stop")
+def stop_workers():
+    """停止所有Ray Worker节点"""
+    typer.echo("🛑 停止Ray Worker节点...")
+    config = load_config()
+    
+    workers_config = config.get('workers', {})
+    worker_nodes = workers_config.get('worker_nodes')
+    ssh_user = workers_config.get('ssh_user', 'sage')
+    ssh_key_path = workers_config.get('ssh_key_path', '~/.ssh/id_rsa')
+    worker_temp_dir = workers_config.get('worker_temp_dir', '/tmp/ray_worker')
+    worker_log_dir = workers_config.get('worker_log_dir', '/tmp/sage_worker_logs')
+    remote_ray_command = workers_config.get('remote_ray_command', '/opt/conda/envs/sage/bin/ray')
+    
+    if not worker_nodes:
+        typer.echo("❌ 配置错误: worker_nodes 未设置")
+        raise typer.Exit(1)
+    
+    nodes = parse_worker_nodes(worker_nodes)
+    success_count = 0
+    total_count = len(nodes)
+    
+    for i, (host, port) in enumerate(nodes, 1):
+        typer.echo(f"\n🔧 停止Worker节点 {i}/{total_count}: {host}:{port}")
+        
+        stop_command = f'''set +e
+export PYTHONUNBUFFERED=1
+
+LOG_DIR='{worker_log_dir}'
+mkdir -p "$LOG_DIR"
+
+echo "===============================================" | tee -a "$LOG_DIR/worker.log"
+echo "Ray Worker停止 ($(date '+%Y-%m-%d %H:%M:%S'))" | tee -a "$LOG_DIR/worker.log"
+echo "Worker节点: $(hostname)" | tee -a "$LOG_DIR/worker.log"
+echo "===============================================" | tee -a "$LOG_DIR/worker.log"
+
+# 初始化conda环境
+{get_conda_init_code()}
+
+# 优雅停止
+echo "[INFO] 正在优雅停止Ray进程..." | tee -a "$LOG_DIR/worker.log"
+{remote_ray_command} stop >> "$LOG_DIR/worker.log" 2>&1 || true
+sleep 2
+
+# 强制停止残留进程
+echo "[INFO] 清理残留的Ray进程..." | tee -a "$LOG_DIR/worker.log"
+for pattern in 'ray.*start' 'raylet' 'core_worker' 'ray::'; do
+    PIDS=$(pgrep -f "$pattern" 2>/dev/null || true)
+    if [[ -n "$PIDS" ]]; then
+        echo "[INFO] 终止进程: $pattern (PIDs: $PIDS)" | tee -a "$LOG_DIR/worker.log"
+        echo "$PIDS" | xargs -r kill -TERM 2>/dev/null || true
+        sleep 1
+        echo "$PIDS" | xargs -r kill -KILL 2>/dev/null || true
+    fi
+done
+
+# 清理临时文件
+WORKER_TEMP_DIR='{worker_temp_dir}'
+if [[ -d "$WORKER_TEMP_DIR" ]]; then
+    echo "[INFO] 清理临时目录: $WORKER_TEMP_DIR" | tee -a "$LOG_DIR/worker.log"
+    rm -rf "$WORKER_TEMP_DIR"/* 2>/dev/null || true
+fi
+
+echo "[SUCCESS] Ray Worker已停止 ($(date '+%Y-%m-%d %H:%M:%S'))" | tee -a "$LOG_DIR/worker.log"'''
+        
+        if execute_remote_command(host, port, stop_command, ssh_user, ssh_key_path, 60):
+            typer.echo(f"✅ Worker节点 {host} 停止成功")
+            success_count += 1
+        else:
+            typer.echo(f"⚠️  Worker节点 {host} 停止完成（可能本来就未运行）")
+            success_count += 1  # 停止操作通常允许失败
+    
+    typer.echo(f"\n📊 停止结果: {success_count}/{total_count} 个节点处理完成")
+    typer.echo("✅ 所有Worker节点停止操作完成！")
+
+@app.command("status")
+def status_workers():
+    """检查所有Ray Worker节点状态"""
+    typer.echo("📊 检查Ray Worker节点状态...")
+    config = load_config()
+    
+    workers_config = config.get('workers', {})
+    head_node = workers_config.get('head_node')
+    worker_nodes = workers_config.get('worker_nodes')
+    head_port = workers_config.get('head_port', 6379)
+    ssh_user = workers_config.get('ssh_user', 'sage')
+    ssh_key_path = workers_config.get('ssh_key_path', '~/.ssh/id_rsa')
+    worker_log_dir = workers_config.get('worker_log_dir', '/tmp/sage_worker_logs')
+    remote_ray_command = workers_config.get('remote_ray_command', '/opt/conda/envs/sage/bin/ray')
+    
+    if not worker_nodes:
+        typer.echo("❌ 配置错误: worker_nodes 未设置")
+        raise typer.Exit(1)
+    
+    nodes = parse_worker_nodes(worker_nodes)
+    running_count = 0
+    total_count = len(nodes)
+    
+    for i, (host, port) in enumerate(nodes, 1):
+        typer.echo(f"\n📋 检查Worker节点 {i}/{total_count}: {host}:{port}")
+        
+        status_command = f'''set +e
+export PYTHONUNBUFFERED=1
+
+echo "==============================================="
+echo "节点状态检查: $(hostname) ($(date '+%Y-%m-%d %H:%M:%S'))"
+echo "==============================================="
+
+# 初始化conda环境
+{get_conda_init_code()}
+
+# 检查Ray进程
+echo "--- Ray进程状态 ---"
+RAY_PIDS=$(pgrep -f 'raylet|core_worker|ray.*start' 2>/dev/null || true)
+if [[ -n "$RAY_PIDS" ]]; then
+    echo "[运行中] 发现Ray进程:"
+    echo "$RAY_PIDS" | while read pid; do
+        if [[ -n "$pid" ]]; then
+            ps -p "$pid" -o pid,ppid,pcpu,pmem,etime,cmd --no-headers 2>/dev/null || true
+        fi
+    done
+    
+    echo ""
+    echo "--- Ray集群连接状态 ---"
+    timeout 10 {remote_ray_command} status 2>/dev/null || echo "[警告] 无法获取Ray集群状态"
+    exit 0
+else
+    echo "[已停止] 未发现Ray进程"
+    exit 1
+fi
+
+echo ""
+echo "--- 网络连通性测试 ---"
+if timeout 5 nc -z {head_node} {head_port} 2>/dev/null; then
+    echo "[正常] 可以连接到头节点 {head_node}:{head_port}"
+else
+    echo "[异常] 无法连接到头节点 {head_node}:{head_port}"
+fi
+
+# 显示最近的日志
+LOG_DIR='{worker_log_dir}'
+if [[ -f "$LOG_DIR/worker.log" ]]; then
+    echo ""
+    echo "--- 最近的日志 (最后5行) ---"
+    tail -5 "$LOG_DIR/worker.log" 2>/dev/null || echo "无法读取日志文件"
+fi
+
+echo "==============================================="'''
+        
+        if execute_remote_command(host, port, status_command, ssh_user, ssh_key_path, 30):
+            typer.echo(f"✅ Worker节点 {host} 正在运行")
+            running_count += 1
+        else:
+            typer.echo(f"❌ Worker节点 {host} 未运行或检查失败")
+    
+    typer.echo(f"\n📊 状态统计: {running_count}/{total_count} 个Worker节点正在运行")
+    if running_count == total_count:
+        typer.echo("✅ 所有Worker节点都在正常运行！")
+    elif running_count > 0:
+        typer.echo("⚠️  部分Worker节点未运行")
+    else:
+        typer.echo("❌ 没有Worker节点在运行")
+
+@app.command("restart")
+def restart_workers():
+    """重启所有Ray Worker节点"""
+    typer.echo("🔄 重启Ray Worker节点...")
+    
+    # 先停止
+    typer.echo("第1步: 停止所有Worker节点")
+    stop_workers()
+    
+    # 等待
+    typer.echo("⏳ 等待3秒后重新启动...")
+    time.sleep(3)
+    
+    # 再启动
+    typer.echo("第2步: 启动所有Worker节点")
+    start_workers()
+    
+    typer.echo("✅ Worker节点重启完成！")
+
+@app.command("config")
+def show_config():
+    """显示当前Worker配置信息"""
+    typer.echo("📋 当前Worker配置信息")
+    config = load_config()
+    
+    workers_config = config.get('workers', {})
+    
+    typer.echo(f"Head节点: {workers_config.get('head_node', 'N/A')}")
+    typer.echo(f"Head端口: {workers_config.get('head_port', 'N/A')}")
+    typer.echo(f"Worker节点: {workers_config.get('worker_nodes', 'N/A')}")
+    typer.echo(f"SSH用户: {workers_config.get('ssh_user', 'N/A')}")
+    typer.echo(f"SSH密钥路径: {workers_config.get('ssh_key_path', 'N/A')}")
+    typer.echo(f"临时目录: {workers_config.get('worker_temp_dir', 'N/A')}")
+    typer.echo(f"日志目录: {workers_config.get('worker_log_dir', 'N/A')}")
+    typer.echo(f"远程SAGE目录: {workers_config.get('remote_sage_home', 'N/A')}")
+    typer.echo(f"远程Python路径: {workers_config.get('remote_python_path', 'N/A')}")
+    typer.echo(f"远程Ray命令: {workers_config.get('remote_ray_command', 'N/A')}")
+
+if __name__ == "__main__":
+    app()

--- a/sage/utils/embedding_methods/embedding.md
+++ b/sage/utils/embedding_methods/embedding.md
@@ -1,0 +1,101 @@
+# Embedding 语言模型本地使用方法说明
+
+## 概述
+
+本文档介绍如何使用 `sage.utils.embedding_methods` 模块中的embedding功能，支持多种embedding模型的本地和远程调用。
+
+## 快速开始
+
+### 基本用法
+
+```python
+from sage.utils.embedding_methods.embedding_api import apply_embedding_model
+
+# 创建embedding模型实例
+model = apply_embedding_model(name="default")
+
+# 生成文本embedding
+embedding = model.embed("hello world")
+
+# 获取embedding维度
+dimension = model.get_dim()
+```
+## 支持的模型类型
+### Default
+使用默认的本能地embedding模型：
+```python
+from sage.utils.embedding_methods.embedding_api import apply_embedding_model
+model = apply_embedding_model("default")
+embedding = model.embed("hello world")
+dimension = model.get_dim()
+```
+
+###Hugging Face 模型
+使用Hugging Face的预训练模型：
+```python
+model = apply_embedding_model(
+    name="hf", 
+    model="sentence-transformers/all-MiniLM-L6-v2"
+)
+embedding = model.embed("This is huggingface.")
+dimension = model.get_dim()
+```
+参数说明：
+model: Hugging Face模型名称
+
+### OpenAI 兼容API
+使用OpenAI格式的API接口：
+
+```python
+model = apply_embedding_model(
+    name="openai",
+    model="BAAI/bge-m3",
+    base_url="https://api.siliconflow.cn/v1",
+    api_key="your_api_key_here"
+)
+embedding = model.embed("this is openai")
+dimension = model.get_dim()
+```
+model: 模型名称
+base_url: API基础URL
+api_key: API密钥
+
+### Jina AI
+使用Jina AI的embedding服务：
+```python
+model = apply_embedding_model(
+    name="jina",
+    model="jina-embeddings-v3",
+    api_key="your_jina_api_key"
+)
+embedding = model.embed("this is jina")
+dimension = model.get_dim()
+```
+参数说明：
+model: Jina模型名称
+api_key: Jina API密钥
+
+## 环境配置
+
+### 环境变量设置
+为了安全使用API密钥，建议使用环境变量：
+```bash
+export SILICONCLOUD_API_KEY=your_siliconcloud_key
+export JINA_API_KEY=your_jina_key
+export OPENAI_API_KEY=your_openai_key
+...
+```
+或者创建`.env`文件：
+```plaintext
+SILICONCLOUD_API_KEY=your_siliconcloud_key
+JINA_API_KEY=your_jina_key
+OPENAI_API_KEY=your_openai_key
+```
+### 在代码中加载环境变量
+```python
+from dotenv import load_dotenv
+import os
+
+load_dotenv(override=False)
+api_key = os.environ.get("JINA_API_KEY")
+```


### PR DESCRIPTION
## feat: 为 SAGE CLI 添加分布式 Ray Worker 节点管理功能

为 SAGE 部署系统添加完整的 Worker 节点管理功能，实现真正意义上的多节点分布式部署能力。

---

### 🌟 新增功能

#### ✅ Worker 管理命令（`sage worker`）

新增 `sage worker` 子命令，用于远程控制多个 Ray Worker 节点：

- `sage worker start` — 通过 SSH 启动所有配置的 worker 节点  
- `sage worker stop` — 停止所有 worker 节点  
- `sage worker status` — 检查 worker 节点状态  
- `sage worker restart` — 重启所有 worker 节点  
- `sage worker config` — 显示当前 worker 配置  

#### ✅ 集成到部署流程

增强 `sage deploy` 命令，集成 worker 启动逻辑：

- `sage deploy start --with-workers` — 启动包含 Worker 的完整集群  
- `sage deploy stop --with-workers` — 停止完整集群  
- 不带 `--with-workers` 时行为保持不变（仅启动 head 节点 + JobManager）

---

### ⚙️ Worker 配置方式

在 `~/.sage/config.yaml` 中新增 `workers` 配置项，例如：

```yaml
workers:
  head_node: "base-sage"
  worker_nodes: "sage2:22,sage4:22"
  ssh_user: "sage"
  ssh_key_path: "~/.ssh/id_rsa"
  head_port: 6379
  worker_temp_dir: "/tmp/ray_worker"
  worker_log_dir: "/tmp/sage_worker_logs"
  remote_sage_home: "/home/sage"
  remote_python_path: "/opt/conda/envs/sage/bin/python"
  remote_ray_command: "/opt/conda/envs/sage/bin/ray"
```

---

### 🧪 使用示例

```bash
# 启动完整分布式集群
sage deploy start --with-workers

# 单独管理 Worker 节点
sage worker start
sage worker status
sage worker stop

# 启动仅包含 Head 节点的集群
sage deploy start

# 检查系统状态
sage deploy status
```

---

### 📦 环境与依赖要求

#### 1. 用户环境准备
- 所有机器需存在 `sage` 用户与名为 `sage` 的 Conda 环境

#### 2. SSH 配置
- 主节点需能通过 SSH 免密登录到所有 Worker 节点
- 确保 SSH 密钥路径正确配置，主节点拥有访问权限

#### 3. Conda 权限配置
- Conda 环境应属于 `sudo` 组，确保 `pip install .` 能安装至正确环境




