### PR TITLE
fix(ci): 修复GitHub Actions缓存权限问题

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -64,21 +64,23 @@ jobs:
     - name: Cache System Dependencies
       uses: actions/cache@v4
       with:
-        path: /var/cache/apt
-        key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/dev-ci.yml') }}
+        path: |
+          ~/.cache/pip
+          /tmp/apt-cache
+        key: ${{ runner.os }}-system-deps-${{ hashFiles('.github/workflows/dev-ci.yml') }}
         restore-keys: |
-          ${{ runner.os }}-apt-
+          ${{ runner.os }}-system-deps-
           
     - name: Install System Dependencies
       run: |
         echo "📦 安装系统依赖..."
-        # 检查缓存状态
-        if [ -f /var/cache/apt/pkgcache.bin ] && [ $(find /var/cache/apt -name "*.bin" -mtime -1 | wc -l) -gt 0 ]; then
-          echo "✅ 使用缓存的包列表"
-        else
-          echo "📥 更新包列表..."
-          sudo apt-get update
-        fi
+        
+        # 创建用户可写的缓存目录
+        mkdir -p /tmp/apt-cache
+        
+        # 更新包列表（优化CI性能）
+        echo "📥 更新包列表..."
+        sudo apt-get update -qq
         
         # 检查包是否已安装
         missing_packages=""


### PR DESCRIPTION
🔧 问题修复:
- 修复'/var/cache/apt'权限拒绝错误
- 将缓存路径改为用户可写目录
- 优化系统依赖安装流程

💡 技术细节:
- 移除对/var/cache/apt的缓存依赖(需要root权限)
- 使用~/.cache/pip和/tmp/apt-cache作为缓存路径
- 简化apt更新逻辑，使用-qq减少输出
- 创建用户可写的临时缓存目录

🎯 解决的错误:

📝 修改文件:
- .github/workflows/dev-ci.yml