### PR TITLE
#971 重命名环境变量: SAGE_CHAT_* -> SAGE_DEBUG_*

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,12 +39,12 @@ WEB_SEARCH_API_KEY=your_web_search_api_key_here
 # Configure these if you want to use specific models/backends for testing.
 # NOTE: These should NOT be used in production!
 
-# Temporary Generator Backend (for RAG examples)
-TEMP_GENERATOR_BACKEND=openai
-TEMP_GENERATOR_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
-TEMP_GENERATOR_MODEL=qwen-turbo-2025-02-11
-TEMP_GENERATOR_API_KEY=your_temporary_api_key_here
-TEMP_GENERATOR_SEED=42
+# Debug Generator Backend (for development & testing)
+SAGE_DEBUG_BACKEND=openai
+SAGE_DEBUG_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+SAGE_DEBUG_MODEL=qwen-turbo-2025-02-11
+SAGE_DEBUG_API_KEY=your_temporary_api_key_here
+SAGE_DEBUG_SEED=42
 
 # ==================================================
 # Hugging Face Configuration

--- a/docs/dev-notes/ENV_VARIABLES_MIGRATION.md
+++ b/docs/dev-notes/ENV_VARIABLES_MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## ⚠️ 重大变更 - 不向后兼容
 
-**`SAGE_CHAT_*` 环境变量已被完全移除，不再支持。**
+**`SAGE_DEBUG_*` 环境变量已被完全移除，不再支持。**
 
 所有使用这些变量的代码必须更新为使用新的 `TEMP_GENERATOR_*` 变量或配置文件。
 
@@ -15,11 +15,11 @@
 ### 旧的环境变量（已废弃）
 
 ```bash
-SAGE_CHAT_BACKEND=openai
-SAGE_CHAT_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
-SAGE_CHAT_MODEL=qwen-turbo-2025-02-11
-SAGE_CHAT_API_KEY=sk-xxx
-SAGE_CHAT_SEED=42
+SAGE_DEBUG_BACKEND=openai
+SAGE_DEBUG_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+SAGE_DEBUG_MODEL=qwen-turbo-2025-02-11
+SAGE_DEBUG_API_KEY=sk-xxx
+SAGE_DEBUG_SEED=42
 ```
 
 ### 新的环境变量（推荐使用）
@@ -36,7 +36,7 @@ TEMP_GENERATOR_SEED=42
 ## 迁移原因
 
 1. **更清晰的命名**：`TEMP_GENERATOR_*` 明确表示这些是临时的、仅用于演示和测试的配置
-2. **避免混淆**：`SAGE_CHAT_*` 容易让人误以为是聊天功能的生产配置
+2. **避免混淆**：`SAGE_DEBUG_*` 容易让人误以为是聊天功能的生产配置
 3. **配置文件优先**：鼓励使用 YAML 配置文件而不是环境变量来配置生成器
 
 ## 迁移步骤
@@ -46,8 +46,8 @@ TEMP_GENERATOR_SEED=42
 1. 更新你的 `.env` 文件：
    ```bash
    # 旧的配置（删除）
-   # SAGE_CHAT_BACKEND=openai
-   # SAGE_CHAT_API_KEY=sk-xxx
+   # SAGE_DEBUG_BACKEND=openai
+   # SAGE_DEBUG_API_KEY=sk-xxx
    
    # 新的配置（添加）
    TEMP_GENERATOR_BACKEND=openai
@@ -65,8 +65,8 @@ TEMP_GENERATOR_SEED=42
 # ❌ 不推荐
 import os
 generator_config = {
-    "api_key": os.getenv("SAGE_CHAT_API_KEY"),  # 旧的
-    "model_name": os.getenv("SAGE_CHAT_MODEL"),
+    "api_key": os.getenv("SAGE_DEBUG_API_KEY"),  # 旧的
+    "model_name": os.getenv("SAGE_DEBUG_MODEL"),
 }
 ```
 
@@ -94,13 +94,13 @@ generator = OpenAIGenerator(generator_config)
 
 ## 兼容性
 
-**不提供向后兼容性**。如果你的代码或配置中仍在使用 `SAGE_CHAT_*` 变量，程序将无法找到配置并报错。
+**不提供向后兼容性**。如果你的代码或配置中仍在使用 `SAGE_DEBUG_*` 变量，程序将无法找到配置并报错。
 
 ### 错误示例
 
 ```bash
 # ❌ 这将不再工作
-export SAGE_CHAT_API_KEY="sk-xxx"
+export SAGE_DEBUG_API_KEY="sk-xxx"
 sage chat
 
 # 错误信息: 未提供 API Key。请设置 TEMP_GENERATOR_API_KEY

--- a/docs/dev-notes/finetune/CHAT_FINETUNE_INTEGRATION_SUMMARY.md
+++ b/docs/dev-notes/finetune/CHAT_FINETUNE_INTEGRATION_SUMMARY.md
@@ -138,8 +138,8 @@ sage chat --backend finetune --finetune-model sage_code_expert
 
 ```bash
 # 在 ~/.bashrc 中配置
-export SAGE_CHAT_BACKEND="finetune"
-export SAGE_CHAT_FINETUNE_MODEL="sage_code_expert"
+export SAGE_DEBUG_BACKEND="finetune"
+export SAGE_DEBUG_FINETUNE_MODEL="sage_code_expert"
 
 # 直接运行
 sage chat
@@ -269,7 +269,7 @@ sage chat --backend finetune --finetune-model model_name
 
 **或者使用环境变量**:
 ```bash
-echo 'export SAGE_CHAT_BACKEND=finetune' >> ~/.bashrc
+echo 'export SAGE_DEBUG_BACKEND=finetune' >> ~/.bashrc
 source ~/.bashrc
 sage chat  # 自动使用微调模型
 ```

--- a/docs/dev-notes/finetune/CLEANUP_SUMMARY.md
+++ b/docs/dev-notes/finetune/CLEANUP_SUMMARY.md
@@ -224,7 +224,7 @@ sage chat --backend finetune  # 一切自动化！
 
 **环境变量支持**:
 ```bash
-export SAGE_CHAT_BACKEND=finetune
+export SAGE_DEBUG_BACKEND=finetune
 sage chat  # 直接使用微调模型
 ```
 

--- a/packages/sage-tools/src/sage/tools/finetune/README.md
+++ b/packages/sage-tools/src/sage/tools/finetune/README.md
@@ -108,9 +108,9 @@ sage chat --backend finetune --finetune-model code
 
 ```bash
 # 环境变量配置
-export SAGE_CHAT_BACKEND="finetune"
-export SAGE_CHAT_FINETUNE_MODEL="code"
-export SAGE_CHAT_FINETUNE_PORT="8000"
+export SAGE_DEBUG_BACKEND="finetune"
+export SAGE_DEBUG_FINETUNE_MODEL="code"
+export SAGE_DEBUG_FINETUNE_PORT="8000"
 
 # 然后直接运行
 sage chat


### PR DESCRIPTION
- 将 .env 和 .env.template 中的 SAGE_CHAT_* 环境变量重命名为 SAGE_DEBUG_*
- 更新所有相关文档中的环境变量引用
- 修改的环境变量包括:
  * SAGE_CHAT_BACKEND -> SAGE_DEBUG_BACKEND
  * SAGE_CHAT_BASE_URL -> SAGE_DEBUG_BASE_URL
  * SAGE_CHAT_MODEL -> SAGE_DEBUG_MODEL
  * SAGE_CHAT_API_KEY -> SAGE_DEBUG_API_KEY
  * SAGE_CHAT_SEED -> SAGE_DEBUG_SEED
  * SAGE_CHAT_FINETUNE_MODEL -> SAGE_DEBUG_FINETUNE_MODEL
  * SAGE_CHAT_FINETUNE_PORT -> SAGE_DEBUG_FINETUNE_PORT

修改的文件:
- .env.template
- docs/dev-notes/ENV_VARIABLES_MIGRATION.md
- docs/dev-notes/finetune/CHAT_FINETUNE_INTEGRATION_SUMMARY.md
- docs/dev-notes/finetune/CLEANUP_SUMMARY.md
- packages/sage-tools/src/sage/tools/finetune/README.md