### PR TITLE
fix: 修复测试失败问题

### DIFF
--- a/packages/sage-middleware/tests/operators/tools/test_tools_coverage.py
+++ b/packages/sage-middleware/tests/operators/tools/test_tools_coverage.py
@@ -20,16 +20,16 @@ class TestImageCaptioner:
         except (ImportError, AttributeError):
             pytest.skip("ImageCaptioner not available")
 
-    @patch("sage.libs.integrations.openaiclient.OpenAIClient")
-    def test_image_captioner_execute(self, mock_openai_client):
+    @patch("sage.middleware.operators.tools.image_captioner.OpenAIClient")
+    def test_image_captioner_execute(self, mock_openai_client_class):
         """Test ImageCaptioner execute method"""
         try:
             from sage.middleware.operators.tools.image_captioner import ImageCaptioner
 
-            # Mock OpenAI client
+            # Mock OpenAI client instance
             mock_client_instance = MagicMock()
             mock_client_instance.generate.return_value = "A photo of a cat"
-            mock_openai_client.return_value = mock_client_instance
+            mock_openai_client_class.return_value = mock_client_instance
 
             captioner = ImageCaptioner()
 
@@ -37,6 +37,7 @@ class TestImageCaptioner:
             if hasattr(captioner, "execute"):
                 result = captioner.execute(image_path="test_image.jpg")
                 assert result is not None
+                assert result == "A photo of a cat"
         except (ImportError, AttributeError):
             pytest.skip("ImageCaptioner not available")
 


### PR DESCRIPTION
- 更新 test_tools_coverage.py 中的导入以匹配实际类名
  - ImageCaptioner: 修复 mock，使用正确的 OpenAIClient
  - TextDetector: 使用 text_detector 类并正确 mock easyocr.Reader
  - ArxivPaperSearcher: 使用 _Searcher_Tool 类
  - UrlTextExtractor: 使用 URL_Text_Extractor_Tool 类
  - NatureNewsFetcher: 使用 Nature_News_Fetcher_Tool 类

- 修复 test_arxiv.py 中的 fitz 依赖问题
  - 在模块级别 mock fitz
  - 在所有测试中 patch FITZ_AVAILABLE
  - 更新所有 Paper 测试以正确 mock fitz 模块

这些修复解决了以下失败的测试：
- test_image_captioner_init
- test_image_captioner_execute
- test_text_detector_init
- test_text_detector_execute
- test_all_tools_importable
- test_arxiv.py 中的所有 Paper 类测试