### PR TITLE
fix(tools): lazy load finetune module to avoid datasets dependency

### DIFF
--- a/packages/sage-tools/src/sage/tools/__init__.py
+++ b/packages/sage-tools/src/sage/tools/__init__.py
@@ -17,8 +17,28 @@ Architecture:
 
 __layer__ = "L6"
 
-from . import cli, dev, finetune
+from . import cli, dev
 from ._version import __version__
+
+
+# 延迟导入 finetune，避免在模块加载时就导入重量级依赖 (datasets, transformers, torch 等)
+def __getattr__(name):
+    """延迟导入 finetune 模块"""
+    if name == "finetune":
+        import importlib
+        import sys
+
+        # 避免递归导入
+        module_name = f"{__name__}.finetune"
+        if module_name in sys.modules:
+            return sys.modules[module_name]
+
+        # 导入 finetune 子模块
+        finetune_module = importlib.import_module(".finetune", package=__name__)
+        return finetune_module
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
- 修复 PyPI 发布时的 ModuleNotFoundError: No module named 'datasets'
- 使用延迟导入避免在 sage-dev 命令执行时加载重量级依赖
- finetune 模块通过 __getattr__ 在实际使用时才导入

问题原因:
- publish-pypi workflow 只安装 sage-tools 包(pip install -e packages/sage-tools)
- build-test workflow 使用 quickstart.sh 安装完整环境，datasets 被间接安装
- 这导致孤立安装场景下才会暴露缺失的 datasets 依赖

解决方案:
- 延迟导入 finetune 模块，避免顶层导入 datasets
- sage-dev 命令无需 datasets/transformers/torch 等依赖
- 符合工具包最小化依赖原则