### PR TITLE
Fix custom agent YAML front matter format (#1136)

### DIFF
--- a/.github/agents/my-agent.agent.md
+++ b/.github/agents/my-agent.agent.md
@@ -1,10 +1,7 @@
-______________________________________________________________________
-
-# Custom agent for SAGE development assistance
-
-# For format details, see: https://gh.io/customagents/config
-
-## name: SAGE Development Assistant description: Expert assistant for SAGE framework development, covering setup, testing, debugging, and best practices
+---
+name: SAGE Development Assistant
+description: Expert assistant for SAGE framework development, covering setup, testing, debugging, and best practices
+---
 
 # SAGE Development Assistant
 


### PR DESCRIPTION
Custom agent `my-agent.agent.md` was not recognized by GitHub Copilot due to invalid metadata format.

## Changes

- Replaced malformed metadata with proper YAML front matter in `.github/agents/my-agent.agent.md`
- Removed separator line and incorrect `## name: ... description: ...` format
- Added standard YAML delimiters (`---`) with structured `name` and `description` fields

**Before:**
```markdown
______________________________________________________________________

# Custom agent for SAGE development assistance

## name: SAGE Development Assistant description: Expert assistant...
```

**After:**
```yaml
---
name: SAGE Development Assistant
description: Expert assistant for SAGE framework development, covering setup, testing, debugging, and best practices
---
```

The custom agent should now be discoverable in GitHub Copilot's agent list when assigning issues.

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> my-agent.agent.md
> 已经创建了，但是为什么在issue里assign给copilot的时候，提示我“This repository has no custom
agents
> Custom agents are reusable instructions and tools in your repository.
> ” 请修复


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

💬 We'd love your input! Share your thoughts on Copilot coding agent in our [2 minute survey](https://gh.io/copilot-coding-agent-survey).

---------