### PR TITLE
fix(ci): increase systemd startup timeout to 600s for LLM model loading

### DIFF
--- a/.github/workflows/deploy-studio.yml
+++ b/.github/workflows/deploy-studio.yml
@@ -442,6 +442,7 @@ jobs:
 
           [Service]
           Type=forking
+          TimeoutStartSec=600
           PIDFile=/home/$RUNNER_USER/.local/state/sage/studio.pid
           User=$RUNNER_USER
           WorkingDirectory=$WORKSPACE


### PR DESCRIPTION
The sage-studio.service was failing with timeout error because:
- systemd default TimeoutStartSec is 90 seconds
- LLM model loading (especially 32B models) takes 2-5 minutes
- sage studio start command waits synchronously for LLM health check

This fix adds TimeoutStartSec=600 to the systemd service configuration, giving enough time for large models to load.