### PR TITLE
chore(tools): govern release-package vs tools boundary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,14 @@ repos:
     pass_filenames: false
     always_run: false
     stages: [pre-commit]
+  - id: release-tools-boundary-check
+    name: check release package vs tools boundary
+    entry: python3 tools/maintenance/checks/check_release_tools_boundary.py
+    language: system
+    pass_filenames: false
+    always_run: false
+    stages: [pre-commit, manual]
+    files: ^(src/sage/(foundation|runtime|stream|serving|edge)/|tools/|quickstart\.sh|manage\.sh|\.pre-commit-config\.yaml)$
           # Check for files in wrong locations under the current meta-repo layout
           # - id: dependency-version-conflicts
           #   name: check dependency version conflicts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,19 @@ feat | fix | refactor | docs | test | perf | ci | chore | build | deps | securit
 
 > PR 必须通过 CI；建议至少 1 名维护者 Review 才可合并（团队策略可调整）。
 
+### 边界变更 PR 检查清单
+
+涉及 `src/sage/**` 或 `tools/**` 的变更，PR 描述中至少要覆盖以下 5 项：
+
+1. 是否新增了 `src/sage/foundation|runtime|stream|serving|edge` 对 `tools` 或 `sage.tools` 的依赖。
+1. 是否把用户安装后必须存在的实现错误地留在 `tools/`。
+1. 是否把仅供安装、维护、CI、hooks、审计使用的逻辑错误地放进 `src/sage`。
+1. 是否说明了迁移触发条件、调用点证据、打包影响和验证范围。
+1. 是否评估了回滚条件：分层方向被破坏、默认依赖膨胀、或 `quickstart.sh` / `sage verify` / 核心导入面失败。
+
+本地可直接运行 `pre-commit run release-tools-boundary-check --all-files`，或执行
+`pre-commit run --all-files` 复核边界守护结果。
+
 ## 分支与工作流
 
 ### 主要分支说明

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -129,6 +129,34 @@ SAGE follows a **minimalist core dependency strategy** with a **modular feature 
 functionality is available either through in-tree extras when it belongs to the SAGE product
 surface, or through independent packages when ownership should stay external.
 
+### Tools vs Release Package Boundary Rules
+
+The root package only publishes code discovered from `src/` in `pyproject.toml`, so ownership
+decisions must follow the release boundary instead of repository convenience.
+
+1. Code that is imported by the public `sage.foundation`, `sage.stream`, `sage.runtime`,
+   `sage.serving`, or `sage.edge` runtime surface must live under `src/sage`.
+1. Code used only by `quickstart.sh`, `manage.sh`, Git hooks, CI checks, maintenance commands, or
+   one-shot migration flows must stay under `tools/`.
+1. Do not add imports from `src/sage/foundation`, `src/sage/runtime`, `src/sage/stream`,
+   `src/sage/serving`, or `src/sage/edge` into `tools` or `sage.tools`, and do not hard-code
+   repository-relative `tools/` paths from those runtime layers.
+1. Install bootstrap, cleanup, repo-governance, documentation checks, hook management, and
+   dependency audit helpers are repository tooling and must remain in `tools/`.
+1. Move a `tools/` implementation into `src/sage` only when it is required by a published user path
+   after install and is reused as product behavior rather than as repository maintenance.
+1. Do not migrate test harnesses, validation reports, sample hook files, or developer-only shell
+   helpers into `src/sage`, even if they are frequently invoked.
+1. Roll back a boundary migration if it introduces upward/development dependencies, expands default
+   release dependencies without product justification, or breaks `quickstart.sh`, `sage verify`, or
+   the core import surface.
+1. Every PR that moves code across the boundary must include evidence for call sites, packaging
+   impact, and validation scope in the description so reviewers can verify the ownership change.
+
+The automated guard is `python3 tools/maintenance/checks/check_release_tools_boundary.py`, wired
+into pre-commit as `release-tools-boundary-check`. It blocks `CRITICAL`/`HIGH` violations and keeps
+new misplaced runtime-layer files as `MEDIUM` warnings until they are intentionally promoted.
+
 ### Per-Layer Dependencies
 
 Current workspace numbering is normalized to the actively maintained main repos:

--- a/tools/maintenance/checks/check_release_tools_boundary.py
+++ b/tools/maintenance/checks/check_release_tools_boundary.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Guard release-package versus tools ownership boundaries."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNTIME_DIRS = [
+    REPO_ROOT / "src/sage/foundation",
+    REPO_ROOT / "src/sage/runtime",
+    REPO_ROOT / "src/sage/stream",
+    REPO_ROOT / "src/sage/serving",
+    REPO_ROOT / "src/sage/edge",
+]
+RUNTIME_EXTENSIONS = {".py"}
+MISPLACED_EXTENSIONS = {".sh", ".bash"}
+MISPLACED_SEGMENTS = {"checks", "hooks", "maintenance", "install", "cleanup"}
+
+IMPORT_PATTERNS = [
+    (
+        "R1",
+        "CRITICAL",
+        re.compile(r"^\s*(?:from\s+tools(?:\.|\s)|import\s+tools(?:\.|\s|$))"),
+        "Release-package runtime code must not import repository-local tools modules.",
+        "Move reusable logic into src/sage or call the helper from CLI/maintenance code instead.",
+    ),
+    (
+        "R1",
+        "CRITICAL",
+        re.compile(r"^\s*(?:from\s+sage\.tools(?:\.|\s)|import\s+sage\.tools(?:\.|\s|$))"),
+        "Core runtime layers must not depend on the in-tree developer tools package.",
+        "Extract the shared contract into foundation/runtime and keep developer orchestration in sage.tools.",
+    ),
+]
+
+PATH_PATTERNS = [
+    (
+        "R2",
+        "HIGH",
+        re.compile(r"['\"][^'\"]*tools/[^'\"]*['\"]"),
+        "Runtime code hard-codes a repository tools path.",
+        "Replace the repo-relative tools path with a stable runtime API or configuration value.",
+    ),
+    (
+        "R2",
+        "HIGH",
+        re.compile(r"(?:Path\s*\([^\n]*\)\s*/\s*['\"]tools['\"]|\.joinpath\(\s*['\"]tools['\"]|os\.path\.join\([^\n]*['\"]tools['\"]|subprocess\.(?:run|Popen|call|check_call|check_output)\([^\n]*tools/)"),
+        "Runtime code constructs or executes a tools path directly.",
+        "Keep repository tooling in maintenance flows and expose a runtime-safe interface if the behavior is required at runtime.",
+    ),
+]
+
+
+@dataclass(slots=True)
+class Finding:
+    rule: str
+    severity: str
+    path: str
+    line: int
+    message: str
+    suggestion: str
+
+
+def _run_git(args: list[str]) -> list[str]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"git {' '.join(args)} failed")
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _runtime_files() -> list[Path]:
+    files: list[Path] = []
+    for directory in RUNTIME_DIRS:
+        if not directory.exists():
+            continue
+        for path in directory.rglob("*.py"):
+            if any(part == "tests" for part in path.parts):
+                continue
+            files.append(path)
+    return sorted(files)
+
+
+def _scan_runtime_files() -> list[Finding]:
+    findings: list[Finding] = []
+    for path in _runtime_files():
+        rel_path = path.relative_to(REPO_ROOT).as_posix()
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for rule, severity, pattern, message, suggestion in IMPORT_PATTERNS + PATH_PATTERNS:
+                if pattern.search(line):
+                    findings.append(
+                        Finding(
+                            rule=rule,
+                            severity=severity,
+                            path=rel_path,
+                            line=line_number,
+                            message=message,
+                            suggestion=suggestion,
+                        )
+                    )
+    return findings
+
+
+def _collect_added_files() -> list[str]:
+    added = set()
+    added.update(_run_git(["diff", "--cached", "--name-only", "--diff-filter=A"]))
+    added.update(_run_git(["diff", "--name-only", "--diff-filter=A"]))
+    added.update(_run_git(["ls-files", "--others", "--exclude-standard"]))
+    return sorted(added)
+
+
+def _scan_misplaced_new_files() -> list[Finding]:
+    findings: list[Finding] = []
+    prefixes = (
+        "src/sage/foundation/",
+        "src/sage/runtime/",
+        "src/sage/stream/",
+        "src/sage/serving/",
+        "src/sage/edge/",
+    )
+    for rel_path in _collect_added_files():
+        if not rel_path.startswith(prefixes):
+            continue
+        path = Path(rel_path)
+        path_text = rel_path.lower()
+        if path.suffix in MISPLACED_EXTENSIONS or any(segment in MISPLACED_SEGMENTS for segment in path.parts):
+            findings.append(
+                Finding(
+                    rule="R3",
+                    severity="MEDIUM",
+                    path=rel_path,
+                    line=1,
+                    message="New file looks like maintenance/install tooling under a runtime-owned package path.",
+                    suggestion="Move repository tooling into tools/maintenance or tools/install unless the file is required by a published runtime surface.",
+                )
+            )
+            continue
+        if "/checks/" in path_text or "/hooks/" in path_text:
+            findings.append(
+                Finding(
+                    rule="R3",
+                    severity="MEDIUM",
+                    path=rel_path,
+                    line=1,
+                    message="New file path introduces checks/hooks semantics under a release package directory.",
+                    suggestion="Place repository checks and hooks under tools/maintenance/checks or hooks instead of src/sage runtime layers.",
+                )
+            )
+    return findings
+
+
+def _print_findings(findings: list[Finding]) -> None:
+    for finding in findings:
+        print(f"SEVERITY: {finding.severity}")
+        print(f"RULE: {finding.rule}")
+        print(f"FILE: {finding.path}:{finding.line}")
+        print(f"MESSAGE: {finding.message}")
+        print(f"SUGGESTION: {finding.suggestion}")
+        print()
+
+
+def _exit_code(findings: list[Finding]) -> int:
+    if any(finding.severity in {"CRITICAL", "HIGH"} for finding in findings):
+        return 1
+    return 0
+
+
+def main() -> int:
+    try:
+        findings = _scan_runtime_files()
+        findings.extend(_scan_misplaced_new_files())
+        findings.sort(key=lambda item: (item.severity, item.path, item.line))
+        _print_findings(findings)
+
+        counts = {level: 0 for level in ("CRITICAL", "HIGH", "MEDIUM")}
+        for finding in findings:
+            counts[finding.severity] = counts.get(finding.severity, 0) + 1
+
+        result = "FAIL" if _exit_code(findings) else "PASS"
+        print(
+            "SUMMARY: total={total} critical={critical} high={high} medium={medium}".format(
+                total=len(findings),
+                critical=counts.get("CRITICAL", 0),
+                high=counts.get("HIGH", 0),
+                medium=counts.get("MEDIUM", 0),
+            )
+        )
+        print(f"RESULT: {result}")
+        return _exit_code(findings)
+    except Exception as exc:
+        print(f"ERROR: boundary check failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document the release-package vs tools ownership rules in the developer guide
- add a PR checklist for boundary changes
- add a new pre-commit guard that blocks runtime-to-tools boundary violations

## What Changed
- added `release-tools-boundary-check` to `.pre-commit-config.yaml`
- added `tools/maintenance/checks/check_release_tools_boundary.py`
- documented authoritative boundary rules in `DEVELOPER.md`
- documented PR review checklist in `CONTRIBUTING.md`

## Audit Snapshot
- audited 95 files under `tools/`
- detected 20 zero-reference candidate files for later manual review
- found no direct `tools` or `sage.tools` dependencies from `src/sage/foundation|runtime|stream|serving|edge` on the current baseline

## Immediate Decisions
- runtime and public API implementations stay in `src/sage`
- install, maintenance, hooks, CI, and repo-governance scripts stay in `tools/`
- runtime code must not import `tools` or hard-code repository-relative `tools/` paths

## Validation
- `python3 tools/maintenance/checks/check_release_tools_boundary.py`
- `pre-commit run release-tools-boundary-check --all-files --config .pre-commit-config.yaml`
- `ruff check --config tools/ruff.toml tools/maintenance/checks/check_release_tools_boundary.py`

## Notes
- `sage-dev quality check --all-files --readme` did not complete cleanly because the current environment's installed entrypoint is out of sync with the workspace and the repo also contains pre-existing lint findings outside this change set.
- this PR keeps `R3` as a warning-only path (`MEDIUM`) and only blocks `CRITICAL` / `HIGH` findings to avoid false-positive developer disruption.

## Rollback Conditions
- false positives start blocking normal runtime-layer changes
- the guard introduces unacceptable pre-commit overhead
- a legitimate runtime path is found to require `sage.tools`, requiring rule refinement before enforcement
