### PR TITLE
fix(install): replace legacy dir refs with actual directory names

### DIFF
--- a/tools/install/checks/comprehensive_check.sh
+++ b/tools/install/checks/comprehensive_check.sh
@@ -3,8 +3,8 @@
 # 按照指定顺序进行系统检查：预检查 -> 通用检查 -> 模式特定检查 -> SAGE 检查
 
 # 导入颜色定义和输出格式化
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/output_formatter.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/output_formatter.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/system_deps.sh"
 
 # ============================================================================

--- a/tools/install/checks/conda_guide.sh
+++ b/tools/install/checks/conda_guide.sh
@@ -6,7 +6,7 @@
 set -e
 
 _CONDA_GUIDE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$_CONDA_GUIDE_DIR/../display_tools/colors.sh"
+source "$_CONDA_GUIDE_DIR/../ui/colors.sh"
 
 # ============================================================
 # Constants

--- a/tools/install/checks/dependency_verification.sh
+++ b/tools/install/checks/dependency_verification.sh
@@ -3,7 +3,7 @@
 # 功能：验证下载包的 checksum、检查安全漏洞（safety/pip-audit）
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # ============================================================================
 # Checksum 验证

--- a/tools/install/checks/environment_prechecks.sh
+++ b/tools/install/checks/environment_prechecks.sh
@@ -3,7 +3,7 @@
 # 实现 2.1 要求：检查磁盘空间、网络连接、内存、CUDA 可用性
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 # 导入 Conda 安装引导模块
 source "$(dirname "${BASH_SOURCE[0]}")/conda_guide.sh"
 

--- a/tools/install/checks/install_verification.sh
+++ b/tools/install/checks/install_verification.sh
@@ -3,7 +3,7 @@
 # 实现全面的安装验证：hello_world 测试、CLI 检查、依赖验证、报告生成
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 设置 Python 命令（使用安装过程中设置的环境变量）
 

--- a/tools/install/checks/mirror_selector.sh
+++ b/tools/install/checks/mirror_selector.sh
@@ -3,7 +3,7 @@
 # 功能：测试多个 PyPI 镜像速度，自动选择最快的
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # PyPI 镜像列表（官方 + 常用国内镜像）
 

--- a/tools/install/checks/sage_check.sh
+++ b/tools/install/checks/sage_check.sh
@@ -3,7 +3,7 @@
 # 处理现有 SAGE 安装的检查、卸载等操作
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 检查是否已安装SAGE
 

--- a/tools/install/checks/system_check.sh
+++ b/tools/install/checks/system_check.sh
@@ -3,7 +3,7 @@
 # 保留验证安装等基础功能
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 验证安装
 

--- a/tools/install/checks/system_deps.sh
+++ b/tools/install/checks/system_deps.sh
@@ -3,7 +3,7 @@
 # 集成到quickstart.sh架构中的系统依赖检查和安装
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 
 # ============================================================================

--- a/tools/install/checks/system_environment_check.sh
+++ b/tools/install/checks/system_environment_check.sh
@@ -3,7 +3,7 @@
 # 全面检查系统环境、硬件配置等
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 检查操作系统及版本
 

--- a/tools/install/fixes/checkpoint_manager.sh
+++ b/tools/install/fixes/checkpoint_manager.sh
@@ -3,7 +3,7 @@
 # 实现安装进度保存、断点续传、自动回滚功能
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 检查点文件路径
 

--- a/tools/install/fixes/cpp_extensions_fix.sh
+++ b/tools/install/fixes/cpp_extensions_fix.sh
@@ -3,7 +3,7 @@
 # 处理 editable install 模式下 C++ 扩展库(.so)的安装问题
 
 # 加载日志和颜色函数（logging.sh 会自动 source colors.sh）
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/logging.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/logging.sh"
 
 # 修复独立适配器 C++ 扩展安装问题（当前仅保留提示功能）
 

--- a/tools/install/fixes/friendly_error_handler.sh
+++ b/tools/install/fixes/friendly_error_handler.sh
@@ -22,8 +22,8 @@ LC_ALL="${LC_ALL:-${LANG}}"
 LC_CTYPE="${LC_CTYPE:-${LANG}}"
 # ============================================================================
 
-if [ -f "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh" ]; then
-    source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+if [ -f "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh" ]; then
+    source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 else
     # 备用颜色定义
     RED='\033[0;31m'

--- a/tools/install/fixes/libstdcxx_fix.sh
+++ b/tools/install/fixes/libstdcxx_fix.sh
@@ -2,7 +2,7 @@
 # libstdc++ 版本兼容性检查与自动升级
 # 目标: 确保提供 GLIBCXX_3.4.30 (sage_flow C++ 扩展所需)
 
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 检测当前 (conda) Python 对应的 libstdc++.so.6 是否包含指定符号
 

--- a/tools/install/fixes/pytorch_cuda_installer.sh
+++ b/tools/install/fixes/pytorch_cuda_installer.sh
@@ -22,8 +22,8 @@ LC_ALL="${LC_ALL:-${LANG}}"
 LC_CTYPE="${LC_CTYPE:-${LANG}}"
 # ============================================================================
 
-if [ -f "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh" ]; then
-    source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+if [ -f "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh" ]; then
+    source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 else
     # 定义基本颜色
     GREEN='\033[0;32m'

--- a/tools/install/installers/argument_parser.sh
+++ b/tools/install/installers/argument_parser.sh
@@ -95,7 +95,7 @@ set_mirror_source_value() {
 SAGE_TOOLS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # 导入颜色定义
-source "$SCRIPT_DIR/../display_tools/colors.sh"
+source "$SCRIPT_DIR/../ui/colors.sh"
 
 # 导入 conda 工具函数
 source "$SAGE_TOOLS_ROOT/install/conda/conda_utils.sh"

--- a/tools/install/installers/clone_satellite_repos.sh
+++ b/tools/install/installers/clone_satellite_repos.sh
@@ -6,7 +6,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 导入颜色定义
-source "$SCRIPT_DIR/../display_tools/colors.sh"
+source "$SCRIPT_DIR/../ui/colors.sh"
 
 # 获取 workspace 文件路径
 SAGE_ROOT="${SAGE_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"

--- a/tools/install/installers/conda_manager.sh
+++ b/tools/install/installers/conda_manager.sh
@@ -3,7 +3,7 @@
 # 处理 conda 环境的创建、激活、管理等操作
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # CI环境或远程部署检测 - 确保非交互模式（静默设置，避免重复输出）
 

--- a/tools/install/installers/core_installer.sh
+++ b/tools/install/installers/core_installer.sh
@@ -3,8 +3,8 @@
 # 负责通过主sage包统一安装所有依赖
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/logging.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/logging.sh"
 
 # 导入友好错误处理
 

--- a/tools/install/installers/dependency_integrity_monitor.sh
+++ b/tools/install/installers/dependency_integrity_monitor.sh
@@ -28,8 +28,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SAGE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 # 导入颜色定义
-if [ -f "$SCRIPT_DIR/../display_tools/colors.sh" ]; then
-    source "$SCRIPT_DIR/../display_tools/colors.sh"
+if [ -f "$SCRIPT_DIR/../ui/colors.sh" ]; then
+    source "$SCRIPT_DIR/../ui/colors.sh"
 else
     RED='\033[0;31m'
     YELLOW='\033[1;33m'
@@ -39,8 +39,8 @@ else
 fi
 
 # 导入日志工具
-if [ -f "$SCRIPT_DIR/../display_tools/logging.sh" ]; then
-    source "$SCRIPT_DIR/../display_tools/logging.sh"
+if [ -f "$SCRIPT_DIR/../ui/logging.sh" ]; then
+    source "$SCRIPT_DIR/../ui/logging.sh"
 fi
 
 echo -e "${BLUE}🔍 CI/CD 安全检查：验证依赖完整性...${NC}"

--- a/tools/install/installers/dev_installer.sh
+++ b/tools/install/installers/dev_installer.sh
@@ -3,7 +3,7 @@
 # 负责安装开发工具相关的依赖包
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 导入核心安装器函数
 source "$(dirname "${BASH_SOURCE[0]}")/core_installer.sh"

--- a/tools/install/installers/environment_config.sh
+++ b/tools/install/installers/environment_config.sh
@@ -3,7 +3,7 @@
 # 统一管理安装环境的配置和设置
 
 # 导入颜色定义（必须在最前面）
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 导入 conda 管理工具
 source "$(dirname "${BASH_SOURCE[0]}")/conda_manager.sh"

--- a/tools/install/installers/main_installer.sh
+++ b/tools/install/installers/main_installer.sh
@@ -3,11 +3,11 @@
 # 统一管理不同安装模式的安装流程
 
 # 导入所有安装器
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/interface.sh"
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/logging.sh"
-source "$(dirname "${BASH_SOURCE[0]}")/../examination_tools/sage_check.sh"
-source "$(dirname "${BASH_SOURCE[0]}")/../download_tools/environment_config.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/interface.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/logging.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../checks/sage_check.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../installers/environment_config.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/core_installer.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/scientific_installer.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/dev_installer.sh"

--- a/tools/install/installers/pip_install_monitor.sh
+++ b/tools/install/installers/pip_install_monitor.sh
@@ -24,8 +24,8 @@ LC_CTYPE="${LC_CTYPE:-${LANG}}"
 set -euo pipefail
 
 # 导入颜色定义（如果可用）
-if [ -f "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh" ]; then
-    source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+if [ -f "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh" ]; then
+    source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 else
     # 简单定义
     RED='\033[0;31m'

--- a/tools/install/installers/scientific_installer.sh
+++ b/tools/install/installers/scientific_installer.sh
@@ -3,7 +3,7 @@
 # 负责安装科学计算相关的依赖包
 
 # 导入颜色定义
-source "$(dirname "${BASH_SOURCE[0]}")/../display_tools/colors.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../ui/colors.sh"
 
 # 导入核心安装器函数
 source "$(dirname "${BASH_SOURCE[0]}")/core_installer.sh"


### PR DESCRIPTION
Rename references in shell scripts from obsolete directory aliases to the current directory structure:
- display_tools/ -> ui/
- examination_tools/ -> checks/
- download_tools/ -> installers/

This fixes 'No such file or directory' errors when running quickstart.sh caused by directory restructuring that was not reflected in the source paths of install scripts.

# Pull Request

## Summary

- What changed:
- Why:

## Scope

- In scope:
- Out of scope:

## Boundary & Dependency Checklist (Mandatory)

- [ ] Change preserves strict layer direction: `L5 -> L4 -> L3 -> L2 -> L1`
- [ ] No compatibility shim / re-export / fallback added
- [ ] Capability ownership is explicit for independent sub-repos (including `sagellm`); no in-repo re-embedding
- [ ] If touching capability families (`neuromem`/`sageVDB`/`sageFlow`/`sageTSDB`/`sagellm`), ownership and rollout order are explicitly stated
- [ ] Algorithm-only contracts remain separate from runtime/service-bound implementation
- [ ] No new `ray` import/dependency (Flownet-first)
- [ ] Any dependency addition is necessary for current layer responsibilities

## No-Compatibility-Layer Self-Check (Mandatory)

- [ ] No dual-path import pattern (`try new_path -> except old_path`)
- [ ] No compatibility alias wrappers kept for migration convenience
- [ ] Call sites are updated directly to canonical import path
- [ ] On missing dependency/path, behavior is fail-fast (no silent fallback)

## Evidence

- Related issue(s):
- Code paths touched:
- Verification commands and key output:

## Risk & Rollback

- Risk:
- Rollback plan:
