### PR TITLE
fix: 补充安装pytest等库的步骤，确保测试正常进行

### DIFF
--- a/.github/workflows/ci-release-install.yml
+++ b/.github/workflows/ci-release-install.yml
@@ -64,6 +64,10 @@ jobs:
           sage verify
           sage chat --help
 
+      - name: Install test dependencies
+        run: |
+          python -m pip install pytest fastapi httpx pytest-asyncio
+
       - name: Run current in-tree tests
         run: |
           python -m pytest src/tests -q


### PR DESCRIPTION
# Pull Request

## Summary

- What changed:

  .github/workflows/ci-release-install.yml                  
                                                            
  - 在运行 pytest 前添加安装测试依赖的步骤：                
                                                            
  - name: Install test dependencies                         
    run: |                                                  
      python -m pip install pytest fastapi httpx pytest-asyncio   

- Why:

  CI 使用 full 模式安装 SAGE，该模式不包含`[dev]`可选依赖（pytest 等）。Install from wheels 步骤使用 `--force-reinstall` 重新安装 wheel 后，环境中没有 pytest，导致`python -m pytest src/tests -q`步骤失败，报错 `No module named pytest `

## Scope

- In scope:
.github/workflows/ci-release-install.yml -   添加测试依赖安装步骤 

- Out of scope:

  不改变 CI 安装模式（保持full），不修改其他 workflow 文件，不修改测试代码

## Boundary & Dependency Checklist (Mandatory)

- [x] Change preserves strict layer direction: `L5 -> L4 -> L3 -> L2 -> L1`
- [x] No compatibility shim / re-export / fallback added
- [x] Capability ownership is explicit for independent sub-repos (including `sagellm`); no in-repo re-embedding
- [x] If touching capability families (`neuromem`/`sageVDB`/`sageFlow`/`sageTSDB`/`sagellm`), ownership and rollout order are explicitly stated
- [x] Algorithm-only contracts remain separate from runtime/service-bound implementation
- [x] No new `ray` import/dependency (Flownet-first)
- [x] Any dependency addition is necessary for current layer responsibilities

## No-Compatibility-Layer Self-Check (Mandatory)

- [x] No dual-path import pattern (`try new_path -> except old_path`)
- [x] No compatibility alias wrappers kept for migration convenience
- [x] Call sites are updated directly to canonical import path
- [x] On missing dependency/path, behavior is fail-fast (no silent fallback)

## Evidence

- Related issue(s):

    CI Installation Test (Release) 失败，错误：`/opt/hostedtoolcache/Python/3.11.15/x64/bin/python: No module named pytest`

- Code paths touched:

  .github/workflows/ci-release-install.yml (第 67-69 行新增)

- Verification commands and key output:

```bash
# 隔离 Python 3.11 venv 中验证                            
pip install pytest fastapi httpx pytest-asyncio           
python -m pytest src/tests -q                             
                                                            
# 结果: 23 passed, 1 skipped, 1 warning in 0.74s   
```

## Risk & Rollback

- Risk:

  极低。仅添加一个 pip install步骤，不影响现有安装流程，不改变 SAGE 包本身

- Rollback plan:

  删除新增的 Install test dependencies step即可恢复到原始状态 
