### PR TITLE
fix(install): harden mirror health checks for #1477

### DIFF
--- a/tools/install/checks/mirror_selector.sh
+++ b/tools/install/checks/mirror_selector.sh
@@ -111,7 +111,8 @@ verify_mirror_download_capability() {
 
     local artifact_url
     artifact_url="$(extract_mirror_artifact_url "$mirror_url" "$test_package" 2>/dev/null || true)"
-    [ -n "$artifact_url" ] || return 0
+    # fail closed: 仅 /simple/ 可达不足以证明 wheel 下载可用
+    [ -n "$artifact_url" ] || return 1
 
     if ! command -v curl >/dev/null 2>&1; then
         return 1

--- a/tools/install/installers/environment_config.sh
+++ b/tools/install/installers/environment_config.sh
@@ -211,7 +211,8 @@ is_mirror_download_healthy() {
 
     local artifact_url
     artifact_url="$(extract_artifact_url_from_simple "$mirror_simple_url" "$test_package" 2>/dev/null || true)"
-    [ -n "$artifact_url" ] || return 0
+    # fail closed: /simple/ 可达但无法解析实际包链接时，不能判定该镜像可下载
+    [ -n "$artifact_url" ] || return 1
 
     local artifact_status
     artifact_status="$(probe_artifact_download_status "$artifact_url")"

--- a/tools/install/tests/test_e2e_integration.sh
+++ b/tools/install/tests/test_e2e_integration.sh
@@ -31,10 +31,10 @@ TEST_DIR="/tmp/sage_e2e_test_$$"
 # 导入颜色定义
 source "${SAGE_ROOT:-}/tools/install/ui/colors.sh"
 
-# 测试结果
+# 测试统计
 TOTAL_STEPS=0
-PASSED_STEPS=0
-FAILED_STEPS=0
+PASSED_CHECKS=0
+FAILED_CHECKS=0
 
 # 日志函数
 log_step() {
@@ -49,13 +49,13 @@ log_step() {
 log_success() {
     local message="$1"
     echo -e "${GREEN}✅ $message${NC}"
-    PASSED_STEPS=$((PASSED_STEPS + 1))
+    PASSED_CHECKS=$((PASSED_CHECKS + 1))
 }
 
 log_failure() {
     local message="$1"
     echo -e "${RED}❌ $message${NC}"
-    FAILED_STEPS=$((FAILED_STEPS + 1))
+    FAILED_CHECKS=$((FAILED_CHECKS + 1))
 }
 
 log_info() {
@@ -170,10 +170,14 @@ step4_test_venv_policy_reject() {
     source "$TEST_DIR/tools/install/ui/colors.sh"
     source "$TEST_DIR/tools/install/installers/environment_config.sh"
 
-    export VIRTUAL_ENV="$TEST_DIR/.venv"
-    if check_virtual_environment_isolation "pip" >/dev/null 2>&1; then
+    unset VIRTUAL_ENV
+    # check_virtual_environment_isolation 在检测到 Python venv 时会直接 exit 1；
+    # 这里放到子 shell 中验证，避免中断整个集成测试进程。
+    if (
+        export VIRTUAL_ENV="$TEST_DIR/.venv"
+        check_virtual_environment_isolation "pip" >/dev/null 2>&1
+    ); then
         log_failure "Python venv 未被拒绝"
-        unset VIRTUAL_ENV
         return 1
     fi
     unset VIRTUAL_ENV
@@ -264,18 +268,19 @@ print_test_summary() {
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${BLUE}${BOLD}测试总结${NC}"
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    local total_checks=$((PASSED_CHECKS + FAILED_CHECKS))
     echo -e "总步骤数: $TOTAL_STEPS"
-    echo -e "${GREEN}通过: $PASSED_STEPS${NC}"
-    echo -e "${RED}失败: $FAILED_STEPS${NC}"
+    echo -e "${GREEN}通过检查项: $PASSED_CHECKS${NC}"
+    echo -e "${RED}失败检查项: $FAILED_CHECKS${NC}"
 
     local pass_rate=0
-    if [ $TOTAL_STEPS -gt 0 ]; then
-        pass_rate=$((PASSED_STEPS * 100 / TOTAL_STEPS))
+    if [ $total_checks -gt 0 ]; then
+        pass_rate=$((PASSED_CHECKS * 100 / total_checks))
     fi
-    echo -e "通过率: ${pass_rate}%"
+    echo -e "检查通过率: ${pass_rate}%"
     echo ""
 
-    if [ $FAILED_STEPS -eq 0 ]; then
+    if [ $FAILED_CHECKS -eq 0 ]; then
         echo -e "${GREEN}${BOLD}✅ 所有集成测试通过！${NC}"
         return 0
     else

--- a/tools/install/tests/test_environment_config.sh
+++ b/tools/install/tests/test_environment_config.sh
@@ -223,6 +223,51 @@ test_check_venv_rejected() {
 }
 
 # ============================================================================
+# 测试镜像下载探测
+# ============================================================================
+
+test_is_mirror_download_healthy_rejects_missing_artifact_url() {
+    echo ""
+    echo -e "${BLUE}测试组: is_mirror_download_healthy - 缺少 artifact URL 时应失败${NC}"
+
+    if (
+        curl() {
+            printf '200'
+        }
+        extract_artifact_url_from_simple() {
+            return 1
+        }
+
+        is_mirror_download_healthy "https://mirror.example/simple" "pip" >/dev/null 2>&1
+    ); then
+        assert_failure "缺少 artifact URL 时不应判定镜像健康"
+        false
+    else
+        assert_success "缺少 artifact URL 时正确拒绝镜像"
+    fi
+}
+
+test_verify_mirror_download_capability_rejects_missing_artifact_url() {
+    echo ""
+    echo -e "${BLUE}测试组: verify_mirror_download_capability - 缺少 artifact URL 时应失败${NC}"
+
+    if (
+        source "${SAGE_ROOT:-}/tools/install/checks/mirror_selector.sh"
+
+        extract_mirror_artifact_url() {
+            return 1
+        }
+
+        verify_mirror_download_capability "https://mirror.example/simple" "pip" >/dev/null 2>&1
+    ); then
+        assert_failure "mirror_selector 缺少 artifact URL 时不应判定可下载"
+        false
+    else
+        assert_success "mirror_selector 缺少 artifact URL 时正确拒绝镜像"
+    fi
+}
+
+# ============================================================================
 # 测试报告
 # ============================================================================
 
@@ -271,6 +316,8 @@ main() {
     test_check_venv_skip_in_ci
     test_check_venv_skip_for_conda_install
     test_check_venv_rejected
+    test_is_mirror_download_healthy_rejects_missing_artifact_url
+    test_verify_mirror_download_capability_rejects_missing_artifact_url
 
     # 打印总结
     print_test_summary


### PR DESCRIPTION
## Summary

Fixes the remaining `#1477` mirror-selection gap on current `main`-based installer code:

- fail closed when a mirror's `/simple/` page is reachable but the actual artifact URL cannot be resolved
- add regression coverage for both `is_mirror_download_healthy()` and `verify_mirror_download_capability()`
- fix the installer E2E test harness so the intentional `venv` rejection is asserted in a subshell
- correct the E2E summary counters to report a real 0-100% pass rate

## Root cause

The installer already had mirror probing and fallback logic, but two health checks still treated:

- `/simple/` reachable, **and**
- artifact URL extraction failed

as a **success** path. That is a fail-open behavior and can still admit mirrors that later return `HTTP 403` on wheel download.

This PR changes that path to fail closed.

## Relationship to the two earlier branch-only commits

Earlier work for the same issue exists in these commits:

- `a0bcbcd5a52022d6dce21da6eaf11a677bed1df5`
- `38cd85c73e0cf47266a8f30b320d2937ac591139`

Those commits are **not on `main`**; they live on `origin/fix/mirror-403-download-fallback` and have no associated merged PR.

This PR is **not a direct cherry-pick** of those SHAs. Instead, it ports the same root-cause intent into today's installer layout on `main`:

- keep the current mirror/fallback structure already present on `main`
- close the remaining fail-open hole
- add regression tests on the current paths under `tools/install/`

So this PR should be read as the **mainline follow-up / finalization** of that earlier unmerged work.

## Verification

Ran locally:

```bash
cd /home/moonlife/hust/SAGE && bash tools/install/tests/run_all_tests.sh
```

Result:

- `环境配置单元测试` ✅
- `清理工具单元测试` ✅
- `端到端集成测试` ✅
- final summary: `总测试套件数: 3 / 通过: 3 / 失败: 0 / 通过率: 100%`

Fixes #1477
