### PR TITLE
Refresh workspace configuration for local app development

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -87,7 +87,8 @@ git checkout main
 - replica 上下文会暴露 `ctx.parallel_index` 与 `ctx.parallelism`，便于算子感知自身副本编号。
 - keyed 数据流在本地运行时按稳定分区路由到固定 replica；非 keyed 数据流按 round-robin 分发。
 - source transformation 仍由本地 source polling 路径驱动，不会因为 `parallelism` 自动变成多个独立本地 source 进程。
-- `FlowNetEnvironment` 会把相同的 `parallelism` hint 编译到 FlowNet actor replica 配置中；本地与 FlowNet 的用户侧并行语义保持一致。
+- `FlowNetEnvironment` 会把相同的 `parallelism` hint 编译到 FlowNet actor replica 配置中；本地与 FlowNet
+  的用户侧并行语义保持一致。
 
 ### Initial Setup
 

--- a/SAGE.code-workspace
+++ b/SAGE.code-workspace
@@ -9,6 +9,26 @@
       "path": "../SAGE-Docs"
     },
     {
+      "name": "my-twin  [app]",
+      "path": "../sage-faculty-twin"
+    },
+    {
+      "name": "personal-homepage  [profile]",
+      "path": "../shuhaozhangtony.github.io"
+    },
+    {
+      "name": "sageVDB  [vdb]",
+      "path": "../sageVDB"
+    },
+    {
+      "name": "neuromem  [memory]",
+      "path": "../neuromem"
+    },
+    {
+      "name": "vllm-hust  [engine]",
+      "path": "../vllm-hust"
+    },
+    {
       "name": "sage-examples  [examples]",
       "path": "../sage-examples"
     },
@@ -17,27 +37,16 @@
       "path": "../sage-tutorials"
     },
     {
-      "name": "sage-faculty-twin  [app]",
-      "path": "../sage-faculty-twin"
-    },
-    {
-      "name": "sageVDB  [vdb]",
-      "path": "../sageVDB"
-    },
-    {
       "name": "vamos  [research]",
       "path": "../vamos"
-    },
-    {
-      "name": "vllm-hust  [engine]",
-      "path": "../vllm-hust"
     }
   ],
   "settings": {
     "python.analysis.extraPaths": [
       "${workspaceFolder:SAGE  [meta]}/src",
-      "${workspaceFolder:sage-faculty-twin  [app]}/src",
-      "${workspaceFolder:sageVDB  [vdb]}"
+      "${workspaceFolder:my-twin  [app]}/src",
+      "${workspaceFolder:sageVDB  [vdb]}",
+      "${workspaceFolder:neuromem  [memory]}"
     ],
     "python.testing.pytestArgs": [
       "packages",
@@ -133,6 +142,25 @@
         }
       },
       {
+        "name": "my-twin: Uvicorn (local neuromem)",
+        "type": "debugpy",
+        "request": "launch",
+        "module": "uvicorn",
+        "args": [
+          "sage_faculty_twin.api:app",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          "8010",
+          "--reload"
+        ],
+        "console": "integratedTerminal",
+        "cwd": "${workspaceFolder:my-twin  [app]}",
+        "env": {
+          "PYTHONPATH": "${workspaceFolder:my-twin  [app]}/src:${workspaceFolder:SAGE  [meta]}/src:${workspaceFolder:sageVDB  [vdb]}:${workspaceFolder:neuromem  [memory]}"
+        }
+      },
+      {
         "name": "Python: sage-dev CLI",
         "type": "debugpy",
         "request": "launch",
@@ -220,6 +248,26 @@
         "isBackground": true,
         "options": {
           "cwd": "${workspaceFolder:SAGE-Docs  [docs]}"
+        }
+      },
+      {
+        "label": "Run my-twin (local neuromem)",
+        "type": "shell",
+        "command": "PYTHONPATH=${workspaceFolder:my-twin  [app]}/src:${workspaceFolder:SAGE  [meta]}/src:${workspaceFolder:sageVDB  [vdb]}:${workspaceFolder:neuromem  [memory]} uvicorn sage_faculty_twin.api:app --host 127.0.0.1 --port 8010 --reload",
+        "group": "build",
+        "problemMatcher": [],
+        "options": {
+          "cwd": "${workspaceFolder:my-twin  [app]}"
+        }
+      },
+      {
+        "label": "Sync Homepage Knowledge (offline)",
+        "type": "shell",
+        "command": "PYTHONPATH=${workspaceFolder:my-twin  [app]}/src:${workspaceFolder:SAGE  [meta]}/src:${workspaceFolder:neuromem  [memory]} python -m sage_faculty_twin.knowledge_import --homepage-dir ${workspaceFolder:personal-homepage  [profile]} --knowledge-dir ${workspaceFolder:my-twin  [app]}/data/knowledge_base --knowledge-backend neuromem",
+        "group": "build",
+        "problemMatcher": [],
+        "options": {
+          "cwd": "${workspaceFolder:my-twin  [app]}"
         }
       }
     ]

--- a/docs/dependency-audit-gate.md
+++ b/docs/dependency-audit-gate.md
@@ -94,8 +94,7 @@ The repo no longer treats the retired split-package layout as a set of direct de
 ### `dev`
 
 - Packages: `fastapi`, `uvicorn`, `httpx`, `pytest`, `pytest-cov`, `pytest-asyncio`, `pytest-mock`,
-  `ruff`, `mypy`, `pre-commit`,
-  `sagepypi @ git+https://github.com/intellistream/sagepypi.git@main`
+  `ruff`, `mypy`, `pre-commit`, `sagepypi @ git+https://github.com/intellistream/sagepypi.git@main`
 - Callsite: `DEVELOPER.md`
 - Rationale: in-tree `sage-dev` developer workflow, validation, and release tooling.
 


### PR DESCRIPTION
This PR refreshes the shared VS Code workspace configuration and related docs.

Summary:
- update the workspace folder ordering and labels for the current multi-repo setup
- add my-twin local debug/task entries and include NeuroMem in the Python path helpers
- apply the formatting/doc cleanup required by the repo hooks

Why:
- the local workspace layout had drifted from the repos currently used together
- the my-twin local run/debug flow should be available directly from the shared workspace
- the docs file was reformatted by the required pre-commit checks while preparing this change