### PR TITLE
fix(runtime): PipelineCompiler._normalize_outputs opt-in flatten for FlatMap/Join

### DIFF
--- a/src/sage/runtime/pipeline_compiler.py
+++ b/src/sage/runtime/pipeline_compiler.py
@@ -463,10 +463,20 @@ class CompiledActorGraph:
             forwarded.input_index = input_index
             queue.append((downstream, forwarded))
 
-    def _normalize_outputs(self, result: Any, collector: Collector | None = None) -> list[Any]:
+    def _normalize_outputs(
+        self,
+        result: Any,
+        collector: Collector | None = None,
+        *,
+        flatten: bool = False,
+    ) -> list[Any]:
         outputs: list[Any] = []
         if result is not None:
-            if hasattr(result, "__iter__") and not isinstance(result, (str, bytes, dict)):
+            if (
+                flatten
+                and hasattr(result, "__iter__")
+                and not isinstance(result, (str, bytes, dict))
+            ):
                 outputs.extend(list(result))
             else:
                 outputs.append(result)
@@ -511,7 +521,7 @@ class CompiledActorGraph:
                 if isinstance(function, FlatMapFunction):
                     function.insert_collector(collector)
                 result = function.execute(packet.payload)
-                for item in self._normalize_outputs(result, collector):
+                for item in self._normalize_outputs(result, collector, flatten=True):
                     self._enqueue_downstreams(
                         queue, transformation, packet.inherit_partition_info(item)
                     )
@@ -525,7 +535,7 @@ class CompiledActorGraph:
                     )
                     return
                 result = function.execute(packet.payload, packet.partition_key, packet.input_index)
-                for item in self._normalize_outputs(result):
+                for item in self._normalize_outputs(result, flatten=True):
                     self._enqueue_downstreams(
                         queue, transformation, packet.inherit_partition_info(item)
                     )


### PR DESCRIPTION
Map/CoMap transformations emit a single item per input. Previously _normalize_outputs would fragment any iterable result (including Pydantic BaseModel whose __iter__ yields (field, value) pairs) into multiple downstream packets when used in non-linear (DAG) topologies.

Add a 'flatten' keyword (default False) so that only FlatMap and Join transformations—whose contracts genuinely emit zero-or-more items per input—opt into the flattening behaviour.

Tests: 86 passed / 1 skipped (SAGE src/tests).