### PR TITLE
docs: finish SAGE canonical URL migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📚 Documentation
-    url: https://github.com/intellistream/SAGE/tree/main/docs
+    url: https://github.com/SAGE-Research/SAGE/tree/main/docs
     about: Check the documentation for guides and API references
   - name: 💬 Discussions
-    url: https://github.com/intellistream/SAGE/discussions
+    url: https://github.com/SAGE-Research/SAGE/discussions
     about: Ask questions and discuss ideas with the community
   - name: 🔒 Security Issues
-    url: https://github.com/intellistream/SAGE/security/advisories/new
+    url: https://github.com/SAGE-Research/SAGE/security/advisories/new
     about: Report security vulnerabilities privately

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -257,7 +257,7 @@ jobs:
           echo "✅ 目录创建完成"
 
       # Note: sage-studio has been moved to an independent repository
-      # (https://github.com/intellistream/sage-studio)
+      # (https://github.com/SAGE-Research/sage-studio)
       # Frontend checks are no longer part of the main SAGE CI pipeline
 
       - name: Run installation validation suite

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -377,7 +377,7 @@ repos:
     exclude: ^(\.secrets\.baseline|\.env\.template|\.github/workflows/|examples/config/.*\.yaml|tests/fixtures/|.*package-lock\.json$|.*\.ipynb$|docs/.*\.md$|examples/.*\.py$|.*\.html$|.*/benchmark_anns/|ThirdParty/|thirdparty/|.*/implementations/(SPTAG|faiss|DiskANN|diskann-ms|candy|puck|pybind11)/)
 
           # SAGE Data Architecture Validation - REMOVED (sage-benchmark is now independent)
-          # See: https://github.com/intellistream/sage-benchmark
+          # See: https://github.com/SAGE-Research/sage-benchmark
 - repo: local
   hooks:
   - id: copilot-instructions-sync-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ git rebase origin/main   # 有冲突时解决后: git add <files> && git rebase 
 ./quickstart.sh --core --yes
 
 # 运行测试（当前推荐方式）
-# 注意：示例已迁移到独立仓库 https://github.com/intellistream/sage-examples
+# 注意：示例已迁移到独立仓库 https://github.com/SAGE-Research/sage-examples
 sage-dev project test --coverage
 
 # 运行全部 pytest （如需要更广覆盖）
@@ -288,7 +288,7 @@ Reduce flakiness via timeout + category filtering.
    ```bash
    ./quickstart.sh --core --yes                # 安装/环境相关改动
    sage-dev project test --coverage            # 核心功能测试
-   # 注意：示例已迁移到 https://github.com/intellistream/sage-examples
+   # 注意：示例已迁移到 https://github.com/SAGE-Research/sage-examples
    ```
 
 1. **集成测试**
@@ -483,7 +483,7 @@ pre-commit run cross-repo-dedup-check --all-files
 | 单个测试       | `pytest src/tests/test_cli_main.py -v`                                  | 直接运行指定测试文件                             |
 | 版本查看       | `python -c "from sage._version import __version__; print(__version__)"` | 确认当前安装版本                                 |
 
-**注意**: 示例和应用已迁移到独立仓库: <https://github.com/intellistream/sage-examples>
+**注意**: 示例和应用已迁移到独立仓库: <https://github.com/SAGE-Research/sage-examples>
 
 > 任何命令失败，请附上一行重现命令与终端输出前 50 行发至 Issue。
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -77,7 +77,7 @@ git checkout main
 - `sage chat --ask "Hello, SAGE!"`
 - `sage index ingest --source ./docs --index local-docs`
 
-> 💡 **注意**: 用户文档已迁移到独立的 [sage-docs](https://github.com/intellistream/sage-docs) 仓库。
+> 💡 **注意**: 用户文档已迁移到独立的 [SAGE-Docs](https://github.com/SAGE-Research/SAGE-Docs) 仓库。
 
 ### Runtime Parallelism Contract
 
@@ -763,7 +763,7 @@ We follow [Semantic Versioning](https://semver.org/):
 ## Getting Help
 
 - **Documentation**: Check `docs/`, `README.md`, and `CONTRIBUTING.md`
-- **Examples**: See [sage-examples](https://github.com/intellistream/sage-examples) repository
+- **Examples**: See [sage-examples](https://github.com/SAGE-Research/sage-examples) repository
 - **Issues**: Search existing issues or create new one
 - **Community**: Join our
   [Slack](https://join.slack.com/t/intellistream/shared_invite/zt-2qayp8bs7-v4F71ge0RkO_rn34hBDWQg)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ git checkout main
 sage verify
 
 # Explore tutorials from the separate learning repo
-git clone https://github.com/intellistream/sage-tutorials.git
+git clone https://github.com/SAGE-Research/sage-tutorials.git
 python sage-tutorials/L1-common/hello_world.py
 ```
 
@@ -289,7 +289,7 @@ Tutorials live in the separate `sage-tutorials` repository so that learning mate
 without drifting the main package contract.
 
 ```bash
-git clone https://github.com/intellistream/sage-tutorials.git
+git clone https://github.com/SAGE-Research/sage-tutorials.git
 cd sage-tutorials
 python L1-common/hello_world.py
 ```
@@ -304,7 +304,7 @@ README.
 - **Architecture**: [https://sage.org.ai/architecture/](https://sage.org.ai/architecture/)
 - **Developer guide**: [DEVELOPER.md](./DEVELOPER.md)
 - **Contribution guide**: [CONTRIBUTING.md](./CONTRIBUTING.md)
-- **Tutorials**: [intellistream/sage-tutorials](https://github.com/intellistream/sage-tutorials)
+- **Tutorials**: [SAGE-Research/sage-tutorials](https://github.com/SAGE-Research/sage-tutorials)
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/intellistream/SAGE"
+Homepage = "https://sage.org.ai/"
 Documentation = "https://intellistream.github.io/SAGE-Docs/"
-Repository = "https://github.com/intellistream/SAGE.git"
-"Bug Tracker" = "https://github.com/intellistream/SAGE/issues"
+Repository = "https://github.com/SAGE-Research/SAGE.git"
+"Bug Tracker" = "https://github.com/SAGE-Research/SAGE/issues"
 
 [tool.setuptools.packages.find]
 namespaces = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://sage.org.ai/"
-Documentation = "https://intellistream.github.io/SAGE-Docs/"
+Documentation = "https://sage.org.ai/getting-started/"
 Repository = "https://github.com/SAGE-Research/SAGE.git"
 "Bug Tracker" = "https://github.com/SAGE-Research/SAGE/issues"
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -301,7 +301,7 @@ _init_sage_workspace() {
     # ── 主 SAGE meta 仓库（当前仓库）─────────────────────────────────────────
     if [ ! -d "$workspace_dir/SAGE/.git" ]; then
         echo -e "  ${CYAN}⬇${NC} clone intellistream/SAGE (meta)..."
-        git clone "https://github.com/intellistream/SAGE.git" "$workspace_dir/SAGE" --depth 1 2>&1 | tail -1 && ((ok++)) || ((fail++))
+        git clone "https://github.com/SAGE-Research/SAGE.git" "$workspace_dir/SAGE" --depth 1 2>&1 | tail -1 && ((ok++)) || ((fail++))
     else
         echo -e "  ${YELLOW}↻${NC} SAGE — 已存在，跳过"
         ((skip++))

--- a/tools/install/checks/install_verification.sh
+++ b/tools/install/checks/install_verification.sh
@@ -347,7 +347,7 @@ verify_sage_imports() {
     # - sageLLM: 独立 PyPI 包 isagellm (pip install isagellm)
     # - sage-examples (原 sage.apps): 已迁移到 sage-examples 仓库
     # - sage.benchmark: 独立 PyPI 包 isage-benchmark (pip install isage-benchmark)
-    # - sage.studio: 独立仓库 https://github.com/intellistream/sage-studio
+    # - sage.studio: 独立仓库 https://github.com/SAGE-Research/sage-studio
     # - sage.edge: 已回归主仓产品面；根包导入应始终可用，FastAPI 运行依赖由 extras 提供
     local sage_packages=(
         "sage.foundation"         # Core: in-tree foundation

--- a/tools/install/fixes/friendly_error_handler.sh
+++ b/tools/install/fixes/friendly_error_handler.sh
@@ -153,9 +153,9 @@ show_friendly_error() {
     fi
 
     echo -e "\n${BLUE}${BOLD}📚 获取更多帮助：${NC}"
-    echo -e "  • 安装故障排除指南：${DIM}https://github.com/intellistream/SAGE/wiki/Troubleshooting${NC}"
-    echo -e "  • 环境配置最佳实践：${DIM}https://github.com/intellistream/SAGE/wiki/Environment-Setup${NC}"
-    echo -e "  • 提交问题报告：${DIM}https://github.com/intellistream/SAGE/issues${NC}"
+    echo -e "  • 安装故障排除指南：${DIM}https://github.com/SAGE-Research/SAGE/wiki/Troubleshooting${NC}"
+    echo -e "  • 环境配置最佳实践：${DIM}https://github.com/SAGE-Research/SAGE/wiki/Environment-Setup${NC}"
+    echo -e "  • 提交问题报告：${DIM}https://github.com/SAGE-Research/SAGE/issues${NC}"
 
     echo -e "\n${BLUE}═══════════════════════════════════════════════════════════════${NC}"
 

--- a/tools/install/fixes/numpy_fix.sh
+++ b/tools/install/fixes/numpy_fix.sh
@@ -245,7 +245,7 @@ show_numpy_error_help() {
     echo -e "     ${DIM}./quickstart.sh${NC}\n"
 
     echo -e "${BLUE}💡 了解更多：${NC}"
-    echo -e "  ${DIM}https://github.com/intellistream/SAGE/wiki/Installation-Troubleshooting${NC}\n"
+    echo -e "  ${DIM}https://github.com/SAGE-Research/SAGE/wiki/Installation-Troubleshooting${NC}\n"
 
     log_info "已显示numpy错误帮助信息" "NumpyFix"
 }

--- a/tools/install/installers/clone_satellite_repos.sh
+++ b/tools/install/installers/clone_satellite_repos.sh
@@ -219,7 +219,7 @@ interactive_clone_repos() {
     echo ""
     echo -e "${YELLOW}💡 提示：${NC}"
     echo -e "${DIM}  如果不克隆，可以稍后手动克隆：${NC}"
-    echo -e "${DIM}  git clone https://github.com/intellistream/sage-examples.git${NC}"
+    echo -e "${DIM}  git clone https://github.com/SAGE-Research/sage-examples.git${NC}"
     echo ""
 
     read -p "是否现在克隆附属仓库？[y/N]: " -r response

--- a/tools/install/ui/interface.sh
+++ b/tools/install/ui/interface.sh
@@ -627,7 +627,7 @@ show_usage_tips() {
     echo -e "${BLUE}独立包（按需安装）：${NC}"
     echo -e "  pip install isage-benchmark             # 性能基准测试"
     echo -e "  pip install isagellm                    # LLM 推理引擎"
-    echo -e "  git clone https://github.com/intellistream/sage-examples # 示例代码"
+    echo -e "  git clone https://github.com/SAGE-Research/sage-examples # 示例代码"
     echo ""
 
     if [ "$mode" = "dev" ] || [ "$mode" = "standard" ]; then


### PR DESCRIPTION
## Summary
- point package metadata and core support links at SAGE-Research/SAGE
- update moved docs, tutorials, examples, studio, and benchmark repository links
- preserve IntelliStream links whose ownership has not changed

## Validation
- `sage-dev quality --check-only`
- `pytest -q src/tests` (134 passed, 1 skipped)
- TOML, YAML, and shell syntax checks
- meta dependency audit gate
- HTTP 200 checks for every new canonical destination
