### PR TITLE
fix(deps): align isagellm verification floor

### DIFF
--- a/dependencies-spec.yaml
+++ b/dependencies-spec.yaml
@@ -23,7 +23,7 @@ isage-flow: ">=0.1.1"  # historical stream package; do not expand as separate lo
 flutty: ">=0.1.0"  # primary optional distributed runtime backend
 isage-refiner: ">=0.1.0"
 isage-neuromem: ">=0.2.1.1"
-isagellm: ">=0.5.1.2"
+isagellm: ">=0.5.4.3"
 isage-anns: ">=0.1.0"
 isage-amms: ">=0.1.0"
 


### PR DESCRIPTION
## Summary

Align the legacy dependency verification specification with the current optional SAGE integration requirement:

- `pyproject.toml`: `isagellm>=0.5.4.3`
- `dependencies-spec.yaml`: `isagellm>=0.5.4.3`

The original #1445 target (`>=0.5.1.3`) is now obsolete: that release is available on PyPI, and the active SAGE package metadata has already advanced to `>=0.5.4.3`. The old installer path named in the issue was removed during the installer consolidation, so there is no second installer pin to update.

Closes #1445.

## Validation

- confirmed the `isagellm 0.5.1.3` release exists on PyPI;
- checked all current repository references to the old `0.5.1.2`/`0.5.1.3` constraints;
- verified the YAML dependency floor now matches `pyproject.toml`;
- `git diff --check`.
