### PR TITLE
chore: ignore local runtime checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,5 @@ FUNDING_INFO.md
 benchmark/experiments/exp1_single_vs_multi/results/*
 SAGE.code-workspace
 .qoder/
+# Independent runtime repositories checked out for local integration work.
+/external/


### PR DESCRIPTION
Keep independently managed runtime repositories under external/ out of the SAGE source tree.